### PR TITLE
Fix errors in the File Processor

### DIFF
--- a/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileGroupInfo.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileGroupInfo.cs
@@ -1,0 +1,52 @@
+﻿//******************************************************************************************************
+//  FileGroupInfo.cs - Gbtc
+//
+//  Copyright © 2021, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  08/05/2021 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.IO;
+using System.Linq;
+
+namespace openXDA.Nodes.Types.FileProcessing
+{
+    public class FileGroupInfo
+    {
+        public string FileGroupPath { get; }
+
+        public FileInfo[] FileGroup => FileGroupFunc()
+            .Where(fileInfo => fileInfo.Exists)
+            .ToArray();
+
+        private Func<FileInfo[]> FileGroupFunc { get; }
+
+        internal FileGroupInfo(string fileGroupPath, Func<FileInfo[]> fileGroupFunc)
+        {
+            FileGroupPath = fileGroupPath;
+            FileGroupFunc = fileGroupFunc;
+        }
+
+        public void Refresh()
+        {
+            foreach (FileInfo fileInfo in FileGroupFunc())
+                fileInfo.Refresh();
+        }
+    }
+}

--- a/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileProcessorIndex.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileProcessorIndex.cs
@@ -1,0 +1,171 @@
+﻿//******************************************************************************************************
+//  FileProcessorIndex.cs - Gbtc
+//
+//  Copyright © 2021, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  08/05/2021 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using GSF.Collections;
+using GSF.IO;
+using log4net;
+
+namespace openXDA.Nodes.Types.FileProcessing
+{
+    public class FileProcessorIndex
+    {
+        #region [ Members ]
+
+        // Nested Types
+
+        private class FileGroupEntry
+        {
+            #region [ Members ]
+
+            // Fields
+            private FileInfo[] m_fileGroup;
+
+            #endregion
+
+            #region [ Constructors ]
+
+            public FileGroupEntry()
+                : this(new HashSet<string>())
+            {
+            }
+
+            public FileGroupEntry(HashSet<string> filePaths)
+            {
+                FilePaths = filePaths;
+
+                FileGroup = filePaths
+                    .Select(filePath => new FileInfo(filePath))
+                    .ToArray();
+            }
+
+            #endregion
+
+            #region [ Properties ]
+
+            public FileInfo[] FileGroup
+            {
+                get => Interlocked.CompareExchange(ref m_fileGroup, null, null);
+                private set => Interlocked.Exchange(ref m_fileGroup, value);
+            }
+
+            private HashSet<string> FilePaths { get; }
+
+            #endregion
+
+            #region [ Methods ]
+
+            public void Add(string filePath)
+            {
+                if (!File.Exists(filePath))
+                    return;
+
+                if (!FilePaths.Add(filePath))
+                    return;
+
+                FileInfo[] fileGroup = FileGroup;
+                int size = fileGroup.Length;
+
+                Array.Resize(ref fileGroup, size + 1);
+                fileGroup[size] = new FileInfo(filePath);
+                FileGroup = fileGroup;
+            }
+
+            public void Prune()
+            {
+                int count = FilePaths.RemoveWhere(path => !File.Exists(path));
+
+                if (count == 0)
+                    return;
+
+                FileGroup = FileGroup
+                    .Where(fileInfo => FilePaths.Contains(fileInfo.FullName))
+                    .ToArray();
+            }
+
+            #endregion
+        }
+
+        #endregion
+
+        #region [ Properties ]
+
+        private HashSet<string> DirectoryIndex { get; }
+            = new HashSet<string>();
+
+        private Dictionary<string, FileGroupEntry> FileGroupIndex { get; }
+            = new Dictionary<string, FileGroupEntry>();
+
+        #endregion
+
+        #region [ Methods ]
+
+        public void Scan(string directory)
+        {
+            if (!DirectoryIndex.Add(directory))
+                return;
+
+            void HandleException(Exception ex) =>
+                Log.Error(ex.Message, ex);
+
+            var groupings = FilePath
+                .EnumerateFiles(directory, "*", SearchOption.TopDirectoryOnly, HandleException)
+                .GroupBy(path => Path.ChangeExtension(path, ".*"));
+
+            foreach (var grouping in groupings)
+            {
+                string key = grouping.Key;
+                HashSet<string> fileGroup = new HashSet<string>(grouping);
+                FileGroupIndex.Add(key, new FileGroupEntry(fileGroup));
+            }
+        }
+
+        public FileGroupInfo Index(string filePath)
+        {
+            string directory = Path.GetDirectoryName(filePath);
+            Scan(directory);
+
+            string key = Path.ChangeExtension(filePath, ".*");
+            FileGroupEntry fileGroupEntry = FileGroupIndex.GetOrAdd(key, _ => new FileGroupEntry());
+            fileGroupEntry.Add(filePath);
+            fileGroupEntry.Prune();
+
+            FileInfo[] GetFileGroup() => fileGroupEntry.FileGroup;
+            FileGroupInfo fileGroupInfo = new FileGroupInfo(key, GetFileGroup);
+            return fileGroupInfo;
+        }
+
+        #endregion
+
+        #region [ Static ]
+
+        // Static Fields
+        private static readonly ILog Log = LogManager.GetLogger(typeof(FileProcessorIndex));
+
+        #endregion
+    }
+}

--- a/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileProcessorNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileProcessorNode.cs
@@ -413,20 +413,6 @@ namespace openXDA.Nodes.Types.FileProcessing
             return FilePath.IsFilePatternMatch(filters, filePath, true);
         }
 
-        private void TryIndexFile(string filePath)
-        {
-            string directory = Path.GetDirectoryName(filePath);
-
-            if (!Index.TryGetValue(directory, out DirectoryIndex directoryIndex))
-                return;
-
-            string fileGroupKey = Path.ChangeExtension(filePath, ".*");
-            List<string> fileGroup = directoryIndex.FileGroups.GetOrAdd(fileGroupKey, key => new List<string>());
-
-            if (!fileGroup.Contains(filePath))
-                fileGroup.Add(filePath);
-        }
-
         private FileInfo[] IndexFile(string filePath)
         {
             string directory = Path.GetDirectoryName(filePath);
@@ -574,15 +560,13 @@ namespace openXDA.Nodes.Types.FileProcessing
             Interlocked.Increment(ref m_scannedFileCount);
 
             string filePath = fileProcessorEventArgs.FullPath;
+            FileInfo[] fileGroup = IndexFile(filePath);
 
             if (!MatchesFilter(filePath))
             {
-                TryIndexFile(filePath);
                 Interlocked.Increment(ref m_skippedFileCount);
                 return;
             }
-
-            FileInfo[] fileGroup = IndexFile(filePath);
 
             int priority = fileProcessorEventArgs.RaisedByFileWatcher
                 ? AnalysisTask.FileWatcherPriority

--- a/Source/Libraries/openXDA.Nodes/openXDA.Nodes.csproj
+++ b/Source/Libraries/openXDA.Nodes/openXDA.Nodes.csproj
@@ -68,7 +68,9 @@
     <Compile Include="Types\Email\EventEmailNode.cs" />
     <Compile Include="Types\Email\EventEmailType.cs" />
     <Compile Include="Types\EPRICapBankAnalysis\EPRICapBankAnalysisNode.cs" />
+    <Compile Include="Types\FileProcessing\FileGroupInfo.cs" />
     <Compile Include="Types\FileProcessing\FileProcessingTask.cs" />
+    <Compile Include="Types\FileProcessing\FileProcessorIndex.cs" />
     <Compile Include="Types\FileProcessing\FileProcessorNode.cs" />
     <Compile Include="Types\FileProcessing\FileSkippedException.cs" />
     <Compile Include="Host.cs" />


### PR DESCRIPTION
Fixes the following errors in the file processor:
* Duplicate FileGroup records due to race conditions between threads that are simultaneously processing the same file group
* Processing failures dependent upon the order in which files in a file group are indexed
* Processing failures due to stale data stuck in retry loops