### PR TITLE
Fix unit labels in dD Tools

### DIFF
--- a/Source/Applications/openXDA/openXDA/wwwroot/Assets/LineSegments.cshtml
+++ b/Source/Applications/openXDA/openXDA/wwwroot/Assets/LineSegments.cshtml
@@ -116,10 +116,10 @@ new[] { "IsEnd", "End of Line", "text-left"},
     <div class="col-md-4">
 
 
-        @Raw(dataContext.AddInputField<LineSegment>("R0", fieldLabel: "R0 (p.u.)"))
-        @Raw(dataContext.AddInputField<LineSegment>("X0", fieldLabel: "X0 (p.u.)"))
-        @Raw(dataContext.AddInputField<LineSegment>("R1", fieldLabel: "R1 (p.u.)"))
-        @Raw(dataContext.AddInputField<LineSegment>("X1", fieldLabel: "X1 (p.u.)"))
+        @Raw(dataContext.AddInputField<LineSegment>("R0", fieldLabel: "R0 (Ohms)"))
+        @Raw(dataContext.AddInputField<LineSegment>("X0", fieldLabel: "X0 (Ohms)"))
+        @Raw(dataContext.AddInputField<LineSegment>("R1", fieldLabel: "R1 (Ohms)"))
+        @Raw(dataContext.AddInputField<LineSegment>("X1", fieldLabel: "X1 (Ohms)"))
     </div>
     <div class="col-md-4">
         @Raw(dataContext.AddInputField<LineSegment>("ThermalRating", fieldLabel: "ThermalRating (A)"))

--- a/Source/Applications/openXDA/openXDA/wwwroot/Assets/LineSegments.cshtml
+++ b/Source/Applications/openXDA/openXDA/wwwroot/Assets/LineSegments.cshtml
@@ -43,7 +43,7 @@
     Dictionary<string, string> parameters = request.QueryParameters();
 
     ViewBag.LineID = -1;
-    ViewBag.lengthUnits = dataContext.Connection.ExecuteScalar<string>("Select Value From [Setting] WHERE Name = 'LengthUnits'");
+    ViewBag.lengthUnits = dataContext.Connection.ExecuteScalar<string>("Select Value From [Setting] WHERE Name = 'DataAnalysis.LengthUnits'");
 
     string LineName = null;
 


### PR DESCRIPTION
@clackner-gpa Can you check the labels for Transformer and Cap Bank Relay impedance values to verify whether they should be labeled per-unit rather than Ohms?

Transformers:
https://github.com/GridProtectionAlliance/openXDA/blob/6b942e8b7a527e7ac3775023f7e19313777cccbd/Source/Applications/openXDA/openXDA/wwwroot/Assets/Transformers.cshtml#L110-L113

Cap bank relays:
https://github.com/GridProtectionAlliance/openXDA/blob/6b942e8b7a527e7ac3775023f7e19313777cccbd/Source/Applications/openXDA/openXDA/wwwroot/Assets/CapacitorBankRelays.cshtml#L106