### PR TITLE
Fix to address SEBrowser performance issues

### DIFF
--- a/Source/Data/01 - openXDA.sql
+++ b/Source/Data/01 - openXDA.sql
@@ -2251,8 +2251,8 @@ Create Table EventWorstDisturbance (
  ID INT IDENTITY(1, 1) NOT NULL PRIMARY KEY,
  EventID INT NOT NULL REFERENCES Event(ID),
  WorstDisturbanceID INT NOT NULL REFERENCES Disturbance(ID),
- WorstLLDisturbanceID INT NOT NULL REFERENCES Disturbance(ID),
- WorstLNDisturbanceID  INT NOT NULL REFERENCES Disturbance(ID)
+ WorstLLDisturbanceID INT NULL REFERENCES Disturbance(ID),
+ WorstLNDisturbanceID  INT NULL REFERENCES Disturbance(ID)
 )
 GO
 

--- a/Source/Libraries/FaultData/DataAnalysis/Disturbance.cs
+++ b/Source/Libraries/FaultData/DataAnalysis/Disturbance.cs
@@ -149,6 +149,11 @@ namespace FaultData.DataAnalysis
             }
         }
 
+        public bool IsWorstDisturbance { get; set; }
+
+        public bool IsLLDisturbance => m_phase == Phase.AB || m_phase == Phase.BC || m_phase == Phase.CA;
+
+        public bool IsLNDisturbance => m_phase == Phase.AN || m_phase == Phase.BN || m_phase == Phase.CN;
         #endregion
 
         #region [ Methods ]

--- a/Source/Libraries/FaultData/DataAnalysis/Disturbance.cs
+++ b/Source/Libraries/FaultData/DataAnalysis/Disturbance.cs
@@ -149,7 +149,7 @@ namespace FaultData.DataAnalysis
             }
         }
 
-        public bool IsWorstDisturbance { get; set; }
+        public bool IsWorstDisturbance { get; set; } = false;
 
         public bool IsLLDisturbance => m_phase == Phase.AB || m_phase == Phase.BC || m_phase == Phase.CA;
 

--- a/Source/Libraries/FaultData/DataAnalysis/VoltageDisturbanceAnalyzer.cs
+++ b/Source/Libraries/FaultData/DataAnalysis/VoltageDisturbanceAnalyzer.cs
@@ -159,12 +159,23 @@ namespace FaultData.DataAnalysis
                 .Select(range =>
                 {
                     Disturbance worst = null;
+                    Disturbance worstLL = null;
+                    Disturbance worstLN = null;
 
                     foreach (Disturbance disturbance in disturbanceList.Where(disturbance => ToDateRange(disturbance).Overlaps(range)))
                     {
                         if ((object)worst == null || m_isMoreSevere(disturbance.PerUnitMagnitude, worst.PerUnitMagnitude))
                             worst = disturbance;
+                        if (disturbance.IsLLDisturbance && ((object)worstLL == null || m_isMoreSevere(disturbance.PerUnitMagnitude, worstLL.PerUnitMagnitude)))
+                            worstLL = disturbance;
+                        if (disturbance.IsLNDisturbance && ((object)worstLN == null || m_isMoreSevere(disturbance.PerUnitMagnitude, worstLN.PerUnitMagnitude)))
+                            worstLN = disturbance;
                     }
+
+                    if (worstLL != null)
+                        worstLL.IsWorstDisturbance = true;
+                    if (worstLN != null)
+                        worstLN.IsWorstDisturbance = true;
 
                     worst.IsWorstDisturbance = true;
                     worst = worst.Clone();
@@ -206,12 +217,23 @@ namespace FaultData.DataAnalysis
                 .Select(range =>
                 {
                     Disturbance worst = null;
+                    Disturbance worstLL = null;
+                    Disturbance worstLN = null;
 
                     foreach (Disturbance disturbance in disturbanceList.Where(disturbance => ToRange(disturbance).Overlaps(range)))
                     {
                         if ((object)worst == null || m_isMoreSevere(disturbance.PerUnitMagnitude, worst.PerUnitMagnitude))
                             worst = disturbance;
+                        if (disturbance.IsLLDisturbance && ((object)worstLL == null || m_isMoreSevere(disturbance.PerUnitMagnitude, worstLL.PerUnitMagnitude)))
+                            worstLL = disturbance;
+                        if (disturbance.IsLNDisturbance &&  ((object)worstLN == null || m_isMoreSevere(disturbance.PerUnitMagnitude, worstLN.PerUnitMagnitude)))
+                            worstLN = disturbance;
                     }
+
+                    if (worstLL != null)
+                        worstLL.IsWorstDisturbance = true;
+                    if (worstLN != null)
+                        worstLN.IsWorstDisturbance = true;
 
                     worst.IsWorstDisturbance = true;
                     worst = worst.Clone();

--- a/Source/Libraries/FaultData/DataAnalysis/VoltageDisturbanceAnalyzer.cs
+++ b/Source/Libraries/FaultData/DataAnalysis/VoltageDisturbanceAnalyzer.cs
@@ -153,6 +153,7 @@ namespace FaultData.DataAnalysis
 
             IEnumerable<Range<DateTime>> allDisturbanceRanges = disturbanceList
                 .Select(ToDateRange);
+            
 
             IEnumerable<Disturbance> worstDisturbances = Range<DateTime>.MergeAllOverlapping(allDisturbanceRanges)
                 .Select(range =>
@@ -165,6 +166,7 @@ namespace FaultData.DataAnalysis
                             worst = disturbance;
                     }
 
+                    worst.IsWorstDisturbance = true;
                     worst = worst.Clone();
                     worst.Phase = Phase.Worst;
                     return worst;
@@ -211,6 +213,7 @@ namespace FaultData.DataAnalysis
                             worst = disturbance;
                     }
 
+                    worst.IsWorstDisturbance = true;
                     worst = worst.Clone();
                     worst.Phase = Phase.Worst;
                     return worst;

--- a/Source/Libraries/FaultData/DataOperations/EventOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/EventOperation.cs
@@ -90,8 +90,9 @@ namespace FaultData.DataOperations
                 List<DataGroup> dataGroups = new List<DataGroup>(cycleDataResource.DataGroups);
                 dataGroups.AddRange(dataGroupsResource.DataGroups.Where(dataGroup => dataGroup.DataSeries.Count == 0));
 
-                List<Event> events = GetEvents(connection, meterDataSet, dataGroups, cycleDataResource.VICycleDataGroups, eventClassificationResource.Classifications);
-                LoadEvents(connection, events, meterDataSet);
+                List<DataGroup> processedDataGroups;
+                List<Event> events = GetEvents(connection, meterDataSet, dataGroups, cycleDataResource.VICycleDataGroups, eventClassificationResource.Classifications, out processedDataGroups);
+                LoadEvents(connection, events, meterDataSet, processedDataGroups);
             }
         }
 
@@ -133,7 +134,7 @@ namespace FaultData.DataOperations
             }
         }
 
-        private List<Event> GetEvents(AdoDataConnection connection, MeterDataSet meterDataSet, List<DataGroup> dataGroups, List<VICycleDataGroup> viCycleDataGroups, Dictionary<DataGroup, EventClassification> eventClassifications)
+        private List<Event> GetEvents(AdoDataConnection connection, MeterDataSet meterDataSet, List<DataGroup> dataGroups, List<VICycleDataGroup> viCycleDataGroups, Dictionary<DataGroup, EventClassification> eventClassifications, out List<DataGroup> processedDataGroups)
         {
             int count = dataGroups
                 .Where(dataGroup => dataGroup.Classification != DataClassification.Trend)
@@ -141,6 +142,7 @@ namespace FaultData.DataOperations
                 .Where(dataGroup => eventClassifications.ContainsKey(dataGroup))
                 .Count();
 
+            processedDataGroups = new List<DataGroup>();
             if (count == 0)
             {
                 Log.Info($"No events found for file '{meterDataSet.FilePath}'.");
@@ -227,6 +229,7 @@ namespace FaultData.DataOperations
 
                 evt.Disturbances.AddRange(GetDisturbances(connection, meterDataSet, dataGroup));
 
+                processedDataGroups.Add(dataGroup);
                 events.Add(evt);
             }
 
@@ -235,12 +238,13 @@ namespace FaultData.DataOperations
             return events;
         }
 
-        private void LoadEvents(AdoDataConnection connection, List<Event> events, MeterDataSet meterDataSet)
+        private void LoadEvents(AdoDataConnection connection, List<Event> events, MeterDataSet meterDataSet, List<DataGroup> dataGroups)
         {
             TableOperations<Event> eventTable = new TableOperations<Event>(connection);
             TableOperations<ChannelData> eventDataTable = new TableOperations<ChannelData>(connection);
             TableOperations<DbDisturbance> disturbanceTable = new TableOperations<DbDisturbance>(connection);
 
+            int i = 0;
             foreach (Event evt in events)
             {
                 IDbDataParameter startTime2 = ToDateTime2(connection, evt.StartTime);
@@ -274,9 +278,61 @@ namespace FaultData.DataOperations
                     disturbanceTable.AddNewRecord(disturbance);
                 }
 
+                LoadWorstDisturbance(connection, evt.ID, GetWorstDisturbances(connection,meterDataSet,dataGroups[i]));
+
                 CheckPQIComponents(meterDataSet, connection, evt);
                 ProcessSnapshots(meterDataSet, evt.ID, connection);
+                i++;
             }
+        }
+
+        private void LoadWorstDisturbance(AdoDataConnection connection, int eventID, List<Disturbance> worstDisturbances)
+        {
+            TableOperations<DbDisturbance> disturbanceTable = new TableOperations<DbDisturbance>(connection);
+            DbDisturbance worstDisturbance = disturbanceTable.QueryRecordWhere("PhaseID = (SELECT ID FROM Phase WHERE Name = 'Worst') AND EventID = {0}", eventID);
+           
+            if (worstDisturbance == null)
+                return;
+
+            Disturbance worstLLDisturbance = worstDisturbances.Where(d => d.IsLLDisturbance).FirstOrDefault();
+            Disturbance worstLNDisturbance = worstDisturbances.Where(d => d.IsLNDisturbance).FirstOrDefault();
+
+
+            EventWorstDisturbance worstDisturbanceRecord = new EventWorstDisturbance()
+            {
+                EventID = eventID,
+                WorstDisturbanceID = worstDisturbance.ID,
+                WorstLLDisturbanceID = GetDisturbanceID(connection, disturbanceTable, worstLLDisturbance, eventID),
+                WorstLNDisturbanceID = GetDisturbanceID(connection, disturbanceTable, worstLNDisturbance, eventID)
+            };
+
+            new TableOperations<EventWorstDisturbance>(connection).AddNewRecord(worstDisturbanceRecord);
+        }
+
+        private int? GetDisturbanceID(AdoDataConnection connection, TableOperations<DbDisturbance> disturbanceTable, Disturbance disturbance, int eventID)
+        {
+            if (disturbance == null)
+                return null;
+
+            DbDisturbance dbDisturbance = GetDisturbanceRow(connection, disturbance);
+            
+            string sql = "EventTypeID = {0} AND ";
+            sql += "PhaseID = {1} AND ";
+            sql += "Magnitude = {2} AND ";
+            sql += "PerUnitMagnitude = {3} AND ";
+            sql += "StartTime = {4} AND ";
+            sql += "EndTime = {5} AND ";
+            sql += "DurationSeconds = {6} AND ";
+            sql += "DurationCycles = {7} AND ";
+            sql += "StartIndex = {8} AND ";
+            sql += "EndIndex = {9} AND ";
+            sql += "EventID = {10}";
+
+            dbDisturbance = disturbanceTable.QueryRecordWhere(sql, dbDisturbance.EventTypeID, dbDisturbance.PhaseID, dbDisturbance.Magnitude, dbDisturbance.PerUnitMagnitude,
+                dbDisturbance.StartTime, dbDisturbance.EndTime, dbDisturbance.DurationSeconds, dbDisturbance.DurationCycles, 
+                dbDisturbance.StartIndex, dbDisturbance.EndIndex, eventID);
+
+            return dbDisturbance?.ID;
         }
 
         private List<DbDisturbance> GetDisturbances(AdoDataConnection connection, MeterDataSet meterDataSet, DataGroup dataGroup)
@@ -325,6 +381,34 @@ namespace FaultData.DataOperations
             return dbDisturbances;
         }
         
+        private List<Disturbance> GetWorstDisturbances(AdoDataConnection connection, MeterDataSet meterDataSet, DataGroup dataGroup)
+        {
+            SagDataResource sagDataResource = meterDataSet.GetResource<SagDataResource>();
+            SwellDataResource swellDataResource = meterDataSet.GetResource<SwellDataResource>();
+            InterruptionDataResource interruptionDataResource = meterDataSet.GetResource<InterruptionDataResource>();
+            TransientDataResource transientDataResource = meterDataSet.GetResource<TransientDataResource>();
+
+            List<Disturbance> disturbances = new List<Disturbance>();
+
+            if (dataGroup.Classification == DataClassification.Unknown)
+                return disturbances;
+
+            if (sagDataResource.Sags.TryGetValue(dataGroup, out disturbances))
+                return disturbances.Where(d => d.IsWorstDisturbance).ToList();
+               
+
+            if (swellDataResource.Swells.TryGetValue(dataGroup, out disturbances))
+                return disturbances.Where(d => d.IsWorstDisturbance).ToList();
+
+            if (interruptionDataResource.Interruptions.TryGetValue(dataGroup, out disturbances))
+                return disturbances.Where(d => d.IsWorstDisturbance).ToList();
+
+            if (transientDataResource.Transients.TryGetValue(dataGroup, out disturbances))
+                return disturbances.Where(d => d.IsWorstDisturbance).ToList();
+
+            return disturbances;
+        }
+
         private DbDisturbance GetDisturbanceRow(AdoDataConnection connection, Disturbance disturbance)
         {
             TableOperations<EventType> eventTypeTable = new TableOperations<EventType>(connection);

--- a/Source/Libraries/FaultData/DataOperations/EventOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/EventOperation.cs
@@ -394,17 +394,17 @@ namespace FaultData.DataOperations
                 return disturbances;
 
             if (sagDataResource.Sags.TryGetValue(dataGroup, out disturbances))
-                return disturbances.Where(d => d.IsWorstDisturbance).ToList();
+                return disturbances.Where(d => d.IsWorstDisturbance && d.Phase != GSF.PQDIF.Logical.Phase.Worst).ToList();
                
 
             if (swellDataResource.Swells.TryGetValue(dataGroup, out disturbances))
-                return disturbances.Where(d => d.IsWorstDisturbance).ToList();
+                return disturbances.Where(d => d.IsWorstDisturbance && d.Phase != GSF.PQDIF.Logical.Phase.Worst).ToList();
 
             if (interruptionDataResource.Interruptions.TryGetValue(dataGroup, out disturbances))
-                return disturbances.Where(d => d.IsWorstDisturbance).ToList();
+                return disturbances.Where(d => d.IsWorstDisturbance && d.Phase != GSF.PQDIF.Logical.Phase.Worst).ToList();
 
             if (transientDataResource.Transients.TryGetValue(dataGroup, out disturbances))
-                return disturbances.Where(d => d.IsWorstDisturbance).ToList();
+                return disturbances.Where(d => d.IsWorstDisturbance && d.Phase != GSF.PQDIF.Logical.Phase.Worst).ToList();
 
             return disturbances;
         }

--- a/Source/Libraries/FaultData/DataResources/TransientDataResource.cs
+++ b/Source/Libraries/FaultData/DataResources/TransientDataResource.cs
@@ -87,6 +87,7 @@ namespace FaultData.DataResources
                 if ((object)worst == null || transiet.PerUnitMagnitude > worst.PerUnitMagnitude)
                     worst = transiet;
 
+                worst.IsWorstDisturbance = true;
                 worst = worst.Clone();
                 worst.Phase = Phase.Worst;
             }

--- a/Source/Libraries/FaultData/DataResources/TransientDataResource.cs
+++ b/Source/Libraries/FaultData/DataResources/TransientDataResource.cs
@@ -81,19 +81,19 @@ namespace FaultData.DataResources
             List<Disturbance> transientList = vaTransients.Concat(vbTransients).Concat(vcTransients).Concat(vabTransients).Concat(vbcTransients).Concat(vcaTransients).ToList();
 
             Disturbance worst = null;
-            foreach (Disturbance transiet in transientList)
+            foreach (Disturbance transient in transientList)
             {
-
-                if ((object)worst == null || transiet.PerUnitMagnitude > worst.PerUnitMagnitude)
-                    worst = transiet;
-
-                worst.IsWorstDisturbance = true;
-                worst = worst.Clone();
-                worst.Phase = Phase.Worst;
+                if ((object)worst == null || transient.PerUnitMagnitude > worst.PerUnitMagnitude)
+                    worst = transient;                
             }
 
             if (worst != null)
+            {
+                worst.IsWorstDisturbance = true;
+                worst = worst.Clone();
+                worst.Phase = Phase.Worst;
                 transientList.Add(worst);
+            }
 
             return transientList;
         }

--- a/Source/Libraries/FaultData/DataResources/TransientDataResource.cs
+++ b/Source/Libraries/FaultData/DataResources/TransientDataResource.cs
@@ -81,11 +81,23 @@ namespace FaultData.DataResources
             List<Disturbance> transientList = vaTransients.Concat(vbTransients).Concat(vcTransients).Concat(vabTransients).Concat(vbcTransients).Concat(vcaTransients).ToList();
 
             Disturbance worst = null;
+            Disturbance worstLL = null;
+            Disturbance worstLN = null;
+
             foreach (Disturbance transient in transientList)
             {
                 if ((object)worst == null || transient.PerUnitMagnitude > worst.PerUnitMagnitude)
-                    worst = transient;                
+                    worst = transient;
+                if (transient.IsLLDisturbance && ((object)worstLL == null || transient.PerUnitMagnitude > worstLL.PerUnitMagnitude))
+                    worstLL = transient;
+                if (transient.IsLNDisturbance && ((object)worstLN == null || transient.PerUnitMagnitude > worstLN.PerUnitMagnitude))
+                    worstLN = transient;
             }
+
+            if (worstLN != null)
+                worstLN.IsWorstDisturbance = true;
+            if (worstLL != null)
+                worstLL.IsWorstDisturbance = true;
 
             if (worst != null)
             {

--- a/Source/Libraries/openXDA.Model/Events/Disturbances/EventWorstDisturbance.cs
+++ b/Source/Libraries/openXDA.Model/Events/Disturbances/EventWorstDisturbance.cs
@@ -32,8 +32,8 @@ namespace openXDA.Model
         public int ID { get; set; }
         public int EventID { get; set; }
         public int WorstDisturbanceID { get; set; }
-        public int WorstLLDisturbanceID { get; set; }
-        public int WorstLNDisturbanceID { get; set; }
+        public int? WorstLLDisturbanceID { get; set; }
+        public int? WorstLNDisturbanceID { get; set; }
 
     }
 


### PR DESCRIPTION
This will add a table to track worst Disturbances for each Event and the associated original Disturbance. Note that the Disturbance is still added to the `Disturbance` Table with `Phase.worst` to ensure this does not break PQDashboard. 