### PR TITLE
Use fault detection logic in SE Browser event filter

### DIFF
--- a/Source/Data/11 - SEBrowser.sql
+++ b/Source/Data/11 - SEBrowser.sql
@@ -88,11 +88,19 @@ FROM
     Disturbance WorstLNDisturbance ON EventWorstDisturbance.WorstLNDisturbanceID = WorstLNDisturbance.ID LEFT OUTER JOIN
     Phase DisturbancePhase ON WorstDisturbance.PhaseID = DisturbancePhase.ID LEFT OUTER JOIN
     EventType DisturbanceType ON WorstDisturbance.EventTypeID = DisturbanceType.ID LEFT OUTER JOIN
+    FaultGroup ON
+        FaultGroup.EventID = Event.ID AND
+        COALESCE(FaultGroup.FaultDetectionLogicResult, 0) <> 0 LEFT OUTER JOIN
     FaultSummary ON
         FaultSummary.EventID = Event.ID AND
         FaultSummary.IsSelectedAlgorithm <> 0 AND
-        FaultSummary.IsValid <> 0 AND
-        FaultSummary.IsSuppressed = 0 AND
+        (
+            FaultGroup.ID IS NOT NULL OR
+            (
+                FaultSummary.IsValid <> 0 AND
+                FaultSummary.IsSuppressed = 0
+            )
+        ) AND
         EventType.Name IN ('Fault', 'RecloseIntoFault')
 WHERE
     EventWorstDisturbance.ID IS NOT NULL OR


### PR DESCRIPTION
If defined, openXDA applies a Boolean expression to the values of the digitals from the meter to determine if a fault occurred in a given event record. The result of that Boolean expression is saved in the `FaultGroup.FaultDetectionLogicResult` field. If no such expression is defined, the value of that field will be `NULL`.

If the `FaultLocation.UseDefaultFaultDetectionLogic` setting is set to `False`, then the event could not have been classified as a fault unless the `FaultGroup.FaultDetectionLogicResult` was set to `1`. Since we are filtering this query by `EventType`, we do not need to check the value of that setting.