### PR TITLE
Add default values to APP trending data folder paths

### DIFF
--- a/Source/Libraries/openXDA.Configuration/TrendingDataSection.cs
+++ b/Source/Libraries/openXDA.Configuration/TrendingDataSection.cs
@@ -31,10 +31,24 @@ namespace openXDA.Configuration
         #region [ Members ]
 
         // Nested Types
-        public class SubSection
+        public class RMSSubSection
         {
             [Setting]
-            [DefaultValue("")]
+            [DefaultValue(@"Trms.dat")]
+            public string FolderPath { get; set; }
+        }
+
+        public class FlickerSubSection
+        {
+            [Setting]
+            [DefaultValue(@"FkrR[0-9]*\.dat")]
+            public string FolderPath { get; set; }
+        }
+
+        public class TriggerSubSection
+        {
+            [Setting]
+            [DefaultValue(@"TrR[0-9]*\.dat")]
             public string FolderPath { get; set; }
         }
 
@@ -49,19 +63,19 @@ namespace openXDA.Configuration
         /// Gets RMS folder path settings.
         /// </summary>
         [Category]
-        public SubSection RMS { get; } = new SubSection();
+        public RMSSubSection RMS { get; } = new RMSSubSection();
 
         /// <summary>
         /// Gets flicker folder path settings.
         /// </summary>
         [Category]
-        public SubSection Flicker { get; } = new SubSection();
+        public FlickerSubSection Flicker { get; } = new FlickerSubSection();
 
         /// <summary>
         /// Gets trigger folder path settings.
         /// </summary>
         [Category]
-        public SubSection Trigger { get; } = new SubSection();
+        public TriggerSubSection Trigger { get; } = new TriggerSubSection();
 
         #endregion
     }


### PR DESCRIPTION
Default value is empty string for all paths:
https://github.com/GridProtectionAlliance/openXDA/blob/eb3972a4217cf5b35c3ca74cb4300c29c9200a35/Source/Libraries/openXDA.Configuration/TrendingDataSection.cs#L37

Defaults in database:
https://github.com/GridProtectionAlliance/openXDA/blob/eb3972a4217cf5b35c3ca74cb4300c29c9200a35/Source/Data/05%20-%20DefaultSettings.sql#L362-L369

If a system does not have these settings defined in the database, openXDA will think that all files are APP RMS files. This can lead to the system processing files just fine but always producing zero events.

See ticket 1232