### PR TITLE
Revert "Removed breaker open type by request of GTC ticket #1144"

### DIFF
--- a/Source/Data/01 - openXDA.sql
+++ b/Source/Data/01 - openXDA.sql
@@ -2516,6 +2516,9 @@ GO
 INSERT INTO EventType(Name, Description) VALUES ('RecloseIntoFault', 'Reclose Into Fault')
 GO
 
+INSERT INTO EventType(Name, Description) VALUES ('BreakerOpen', 'Breaker Opening - Nonfault')
+GO
+
 INSERT INTO EventType(Name, Description) VALUES ('Interruption', 'Interruption')
 GO
 


### PR DESCRIPTION
This was mistakenly considered to be a resolution to an issue raised by GTC, but this change actually has almost no effect on the system. If we need to remove this event type from their database to resolve their issue, we should just do that instead of modifying the openXDA.sql script.

This reverts commit d7b1e4588928fbae924b6e681a14e5eb30e83c73.