### PR TITLE
PQDif Channel Fix and SQL Cleanup Node

### DIFF
--- a/Source/Data/01 - openXDA.sql
+++ b/Source/Data/01 - openXDA.sql
@@ -295,7 +295,7 @@ GO
 INSERT INTO NodeType VALUES('SSAMS', 'openXDA.Nodes.dll', 'openXDA.Nodes.Types.SSAMS.SSAMSNode')
 GO
 
-INSERT INTO NodeType VALUES('DataBaseMaintenance', 'openXDA.Nodes.dll', 'openXDA.Nodes.Types.DataBaseMaintenance.DataBaseMaintenanceNode')
+INSERT INTO NodeType VALUES('DatabaseMaintenance', 'openXDA.Nodes.dll', 'openXDA.Nodes.Types.DatabaseMaintenance.DatabaseMaintenanceNode')
 GO
 
 CREATE TABLE Node

--- a/Source/Data/01 - openXDA.sql
+++ b/Source/Data/01 - openXDA.sql
@@ -295,6 +295,9 @@ GO
 INSERT INTO NodeType VALUES('SSAMS', 'openXDA.Nodes.dll', 'openXDA.Nodes.Types.SSAMS.SSAMSNode')
 GO
 
+INSERT INTO NodeType VALUES('DataBaseMaintenance', 'openXDA.Nodes.dll', 'openXDA.Nodes.Types.DataBaseMaintenance.DataBaseMaintenanceNode')
+GO
+
 CREATE TABLE Node
 (
     ID INT IDENTITY(1, 1) NOT NULL PRIMARY KEY,

--- a/Source/Libraries/openXDA.Nodes/Types/DatabaseMaintenance/DataBaseMaintenanceNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/DatabaseMaintenance/DataBaseMaintenanceNode.cs
@@ -1,0 +1,116 @@
+﻿//******************************************************************************************************
+//  DataBaseMaintenanceNode.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  01/16/2023 - C. Lackner
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using GSF.Configuration;
+using GSF.Data;
+using GSF.Data.Model;
+using GSF.Threading;
+using log4net;
+using openXDA.Configuration;
+using openXDA.DataPusher;
+using openXDA.Model;
+
+namespace openXDA.Nodes.Types.DataBaseMaintenance
+{
+    public class DataBaseMaintenanceNode : NodeBase
+    {
+        #region [ Members ]
+
+        // Nested Types
+        private class DataBaseMaintenanceController : ApiController
+        {
+            private DataBaseMaintenanceNode Node { get; }
+
+            public DataBaseMaintenanceController(DataBaseMaintenanceNode node) =>
+                Node = node;
+        }
+
+        #endregion
+
+        #region [ Constructors ]
+
+        public DataBaseMaintenanceNode(Host host, Node definition, NodeType type)
+            : base(host, definition, type)
+        {
+            ScheduleAllInstances();
+        }
+
+        #endregion
+
+        #region [ Properties ]
+
+
+        #endregion
+
+        #region [ Methods ]
+
+        public override IHttpController CreateWebController() =>
+            new DataBaseMaintenanceController(this);
+
+        protected override void OnReconfigure(Action<object> configurator)
+        {
+            ScheduleAllInstances();
+        }
+
+        private void ScheduleAllInstances()
+        {            
+            using (AdoDataConnection connection = new AdoDataConnection("systemSettings"))
+            {
+                IEnumerable<DBCleanup> allInstances = new TableOperations<DBCleanup>(connection).QueryRecords();
+                foreach (DBCleanup instance in allInstances)
+                {
+                    string name = $"{nameof(RunInstance)}_ID:{instance.ID}";
+                    Host.RegisterScheduledProcess(this, RunInstance(instance), name, instance.Schedule);
+                }
+            }
+        }
+
+        private Action RunInstance(DBCleanup instance)
+        {
+           Action<object> configurator = GetConfigurator();
+            return () =>
+            {
+                using (AdoDataConnection connection = new AdoDataConnection("systemSettings"))
+                {
+                    connection.ExecuteNonQuery(instance.SQLCommand);
+                    Log.Info($"Ran cleanup Task: {instance.Name}");
+                }
+            };
+        }
+
+        #endregion
+
+        #region [ Static ]
+
+        // Static Fields
+        private static readonly ILog Log = LogManager.GetLogger(typeof(DataBaseMaintenanceNode));
+
+        #endregion
+    }
+}

--- a/Source/Libraries/openXDA.Nodes/Types/DatabaseMaintenance/DataBaseMaintenanceNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/DatabaseMaintenance/DataBaseMaintenanceNode.cs
@@ -23,39 +23,18 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Threading.Tasks;
-using System.Web.Http;
-using System.Web.Http.Controllers;
-using GSF.Configuration;
 using GSF.Data;
 using GSF.Data.Model;
-using GSF.Threading;
 using log4net;
-using openXDA.Configuration;
-using openXDA.DataPusher;
 using openXDA.Model;
 
-namespace openXDA.Nodes.Types.DataBaseMaintenance
+namespace openXDA.Nodes.Types.DatabaseMaintenance
 {
-    public class DataBaseMaintenanceNode : NodeBase
+    public class DatabaseMaintenanceNode : NodeBase
     {
-        #region [ Members ]
-
-        // Nested Types
-        private class DataBaseMaintenanceController : ApiController
-        {
-            private DataBaseMaintenanceNode Node { get; }
-
-            public DataBaseMaintenanceController(DataBaseMaintenanceNode node) =>
-                Node = node;
-        }
-
-        #endregion
-
         #region [ Constructors ]
 
-        public DataBaseMaintenanceNode(Host host, Node definition, NodeType type)
+        public DatabaseMaintenanceNode(Host host, Node definition, NodeType type)
             : base(host, definition, type)
         {
             ScheduleAllInstances();
@@ -63,26 +42,17 @@ namespace openXDA.Nodes.Types.DataBaseMaintenance
 
         #endregion
 
-        #region [ Properties ]
-
-
-        #endregion
-
         #region [ Methods ]
 
-        public override IHttpController CreateWebController() =>
-            new DataBaseMaintenanceController(this);
-
-        protected override void OnReconfigure(Action<object> configurator)
-        {
+        protected override void OnReconfigure(Action<object> configurator) =>
             ScheduleAllInstances();
-        }
 
         private void ScheduleAllInstances()
         {            
             using (AdoDataConnection connection = new AdoDataConnection("systemSettings"))
             {
                 IEnumerable<DBCleanup> allInstances = new TableOperations<DBCleanup>(connection).QueryRecords();
+
                 foreach (DBCleanup instance in allInstances)
                 {
                     string name = $"{nameof(RunInstance)}_ID:{instance.ID}";
@@ -93,7 +63,8 @@ namespace openXDA.Nodes.Types.DataBaseMaintenance
 
         private Action RunInstance(DBCleanup instance)
         {
-           Action<object> configurator = GetConfigurator();
+            Action<object> configurator = GetConfigurator();
+
             return () =>
             {
                 using (AdoDataConnection connection = new AdoDataConnection("systemSettings"))
@@ -109,7 +80,7 @@ namespace openXDA.Nodes.Types.DataBaseMaintenance
         #region [ Static ]
 
         // Static Fields
-        private static readonly ILog Log = LogManager.GetLogger(typeof(DataBaseMaintenanceNode));
+        private static readonly ILog Log = LogManager.GetLogger(typeof(DatabaseMaintenanceNode));
 
         #endregion
     }

--- a/Source/Libraries/openXDA.Nodes/openXDA.Nodes.csproj
+++ b/Source/Libraries/openXDA.Nodes/openXDA.Nodes.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Types\Analysis\AnalysisTaskPublisher.cs" />
     <Compile Include="ConfigurationLoader.cs" />
     <Compile Include="Types\Authentication\AuthenticationProviderNode.cs" />
+    <Compile Include="Types\DatabaseMaintenance\DataBaseMaintenanceNode.cs" />
     <Compile Include="Types\DataPusher\DataPusherNode.cs" />
     <Compile Include="Types\Email\EventEmailNode.cs" />
     <Compile Include="Types\Email\EventEmailProcessor.cs" />

--- a/Source/Libraries/openXDA.Nodes/openXDA.Nodes.csproj
+++ b/Source/Libraries/openXDA.Nodes/openXDA.Nodes.csproj
@@ -75,7 +75,7 @@
     <Compile Include="Types\Analysis\AnalysisTaskPublisher.cs" />
     <Compile Include="ConfigurationLoader.cs" />
     <Compile Include="Types\Authentication\AuthenticationProviderNode.cs" />
-    <Compile Include="Types\DatabaseMaintenance\DataBaseMaintenanceNode.cs" />
+    <Compile Include="Types\DatabaseMaintenance\DatabaseMaintenanceNode.cs" />
     <Compile Include="Types\DataPusher\DataPusherNode.cs" />
     <Compile Include="Types\Email\EventEmailNode.cs" />
     <Compile Include="Types\Email\EventEmailProcessor.cs" />


### PR DESCRIPTION
This is a combination of 2 issues:
(1) Fixed PQDif channel mappings to use Name (SourceIndices or Channel.Name if NULL) if it can not find it via Asset, Type etc
(2) Added the SQLCleanup logic from MiMD. I will make a separate pull request in MiMD to remove it there. it's used for various tasks unrelate to MiMD so it fits better here