### PR TITLE
Added support for storing and using fast RMS data from PQube meters.

### DIFF
--- a/Source/Libraries/FaultData/DataAnalysis/DataGroup.cs
+++ b/Source/Libraries/FaultData/DataAnalysis/DataGroup.cs
@@ -40,6 +40,7 @@ namespace FaultData.DataAnalysis
     {
         Trend,
         Event,
+        FastRMS,
         Unknown
     }
 
@@ -48,7 +49,7 @@ namespace FaultData.DataAnalysis
         #region [ Members ]
 
         // Constants
-        
+
         /// <summary>
         /// Maximum sample rate, in samples per minute, of data classified as <see cref="DataClassification.Trend"/>.
         /// </summary>
@@ -318,7 +319,7 @@ namespace FaultData.DataAnalysis
 
                 return true;
             }
-            
+
             // If the data being added matches the parameters for this data group, add the data to the data group
             // Note that it does not have to match Asset
             if (startTime == m_startTime && endTime == m_endTime && samples == m_samples)
@@ -665,6 +666,8 @@ namespace FaultData.DataAnalysis
                 m_classification = DataClassification.Trend;
             else if (IsEvent())
                 m_classification = DataClassification.Event;
+            else if (IsFastRMS())
+                m_classification = DataClassification.FastRMS;
             else
                 m_classification = DataClassification.Unknown;
         }
@@ -696,6 +699,23 @@ namespace FaultData.DataAnalysis
             string seriesTypeName = dataSeries.SeriesInfo.SeriesType.Name;
 
             return (characteristicName == "Instantaneous") &&
+                   (seriesTypeName == "Values" || seriesTypeName == "Instantaneous");
+        }
+
+        private bool IsFastRMS()
+        {
+            return m_dataSeries
+                .Where(dataSeries => (object)dataSeries.SeriesInfo != null)
+                .Where(IsRMS)
+                .Any();
+        }
+
+        private bool IsRMS(DataSeries dataSeries)
+        {
+            string characteristicName = dataSeries.SeriesInfo.Channel.MeasurementCharacteristic.Name;
+            string seriesTypeName = dataSeries.SeriesInfo.SeriesType.Name;
+
+            return (characteristicName == "RMS") &&
                    (seriesTypeName == "Values" || seriesTypeName == "Instantaneous");
         }
 

--- a/Source/Libraries/FaultData/DataAnalysis/VoltageDisturbanceAnalyzer.cs
+++ b/Source/Libraries/FaultData/DataAnalysis/VoltageDisturbanceAnalyzer.cs
@@ -99,10 +99,12 @@ namespace FaultData.DataAnalysis
             {
                 DataGroup dataGroup = cycleDataResource.DataGroups[i];
                 VICycleDataGroup viCycleDataGroup = cycleDataResource.VICycleDataGroups[i];
-                Range<DateTime> eventDateRange = new Range<DateTime>(dataGroup.StartTime, dataGroup.EndTime);
+                FastRMSDataResource fastRMSDataResource = meterDataSet.GetResource<FastRMSDataResource>();
 
                 if (assetCount == 1 && dataGroup.Disturbances.Count > 0)
                     ProcessReportedDisturbances(meterDataSet.Meter, dataGroup);
+                else if (fastRMSDataResource.FastRMSLookup.TryGetValue(dataGroup, out DataGroup fastRMS))
+                    DetectDisturbances(dataGroup, fastRMS);
                 else
                     DetectDisturbances(dataGroup, viCycleDataGroup);
             }
@@ -201,19 +203,56 @@ namespace FaultData.DataAnalysis
 
         private void DetectDisturbances(DataGroup dataGroup, VICycleDataGroup viCycleDataGroup)
         {
-            List<Range<int>> aPhaseDisturbanceRanges = DetectDisturbanceRanges(ToPerUnit(viCycleDataGroup.VA?.RMS));
-            List<Range<int>> bPhaseDisturbanceRanges = DetectDisturbanceRanges(ToPerUnit(viCycleDataGroup.VB?.RMS));
-            List<Range<int>> cPhaseDisturbanceRanges = DetectDisturbanceRanges(ToPerUnit(viCycleDataGroup.VC?.RMS));
-            List<Range<int>> abPhaseDisturbanceRanges = DetectDisturbanceRanges(ToPerUnit(viCycleDataGroup.VAB?.RMS));
-            List<Range<int>> bcPhaseDisturbanceRanges = DetectDisturbanceRanges(ToPerUnit(viCycleDataGroup.VBC?.RMS));
-            List<Range<int>> caPhaseDisturbanceRanges = DetectDisturbanceRanges(ToPerUnit(viCycleDataGroup.VCA?.RMS));
+            DataSeries va = viCycleDataGroup.VA?.RMS;
+            DataSeries vb = viCycleDataGroup.VB?.RMS;
+            DataSeries vc = viCycleDataGroup.VC?.RMS;
+            DataSeries vab = viCycleDataGroup.VAB?.RMS;
+            DataSeries vbc = viCycleDataGroup.VBC?.RMS;
+            DataSeries vca = viCycleDataGroup.VCA?.RMS;
 
-            List<Disturbance> disturbanceList = aPhaseDisturbanceRanges.Select(range => ToDisturbance(viCycleDataGroup.VA.RMS, range, Phase.AN))
-                .Concat(bPhaseDisturbanceRanges.Select(range => ToDisturbance(viCycleDataGroup.VB.RMS, range, Phase.BN)))
-                .Concat(cPhaseDisturbanceRanges.Select(range => ToDisturbance(viCycleDataGroup.VC.RMS, range, Phase.CN)))
-                .Concat(abPhaseDisturbanceRanges.Select(range => ToDisturbance(viCycleDataGroup.VAB.RMS, range, Phase.AB)))
-                .Concat(bcPhaseDisturbanceRanges.Select(range => ToDisturbance(viCycleDataGroup.VBC.RMS, range, Phase.BC)))
-                .Concat(caPhaseDisturbanceRanges.Select(range => ToDisturbance(viCycleDataGroup.VCA.RMS, range, Phase.CA)))
+            List<Disturbance> disturbanceList = GetDisturbanceList(va, vb, vc, vab, vbc, vca);
+
+            if (disturbanceList.Any())
+                m_disturbances.Add(dataGroup, disturbanceList);
+        }
+
+        private void DetectDisturbances(DataGroup dataGroup, DataGroup fastRMS)
+        {
+            DataSeries GetVoltageRMS(string phase) => fastRMS.DataSeries
+                .Where(dataSeries => dataSeries.SeriesInfo.Channel.MeasurementType.Name == "Voltage")
+                .Where(dataSeries => dataSeries.SeriesInfo.Channel.Phase.Name == phase)
+                .Where(dataSeries => dataSeries.SeriesInfo.Channel.MeasurementCharacteristic.Name == "RMS")
+                .Where(dataSeries => new[] { "Values", "Instantaneous" }.Contains(dataSeries.SeriesInfo.SeriesType.Name))
+                .FirstOrDefault();
+
+            DataSeries va = GetVoltageRMS("AN");
+            DataSeries vb = GetVoltageRMS("BN");
+            DataSeries vc = GetVoltageRMS("CN");
+            DataSeries vab = GetVoltageRMS("AB");
+            DataSeries vbc = GetVoltageRMS("BC");
+            DataSeries vca = GetVoltageRMS("CA");
+
+            List<Disturbance> disturbanceList = GetDisturbanceList(va, vb, vc, vab, vbc, vca);
+
+            if (disturbanceList.Any())
+                m_disturbances.Add(dataGroup, disturbanceList);
+        }
+
+        private List<Disturbance> GetDisturbanceList(DataSeries va, DataSeries vb, DataSeries vc, DataSeries vab, DataSeries vbc, DataSeries vca)
+        {
+            List<Range<int>> aPhaseDisturbanceRanges = DetectDisturbanceRanges(ToPerUnit(va));
+            List<Range<int>> bPhaseDisturbanceRanges = DetectDisturbanceRanges(ToPerUnit(vb));
+            List<Range<int>> cPhaseDisturbanceRanges = DetectDisturbanceRanges(ToPerUnit(vc));
+            List<Range<int>> abPhaseDisturbanceRanges = DetectDisturbanceRanges(ToPerUnit(vab));
+            List<Range<int>> bcPhaseDisturbanceRanges = DetectDisturbanceRanges(ToPerUnit(vbc));
+            List<Range<int>> caPhaseDisturbanceRanges = DetectDisturbanceRanges(ToPerUnit(vca));
+
+            List<Disturbance> disturbanceList = aPhaseDisturbanceRanges.Select(range => ToDisturbance(va, range, Phase.AN))
+                .Concat(bPhaseDisturbanceRanges.Select(range => ToDisturbance(vb, range, Phase.BN)))
+                .Concat(cPhaseDisturbanceRanges.Select(range => ToDisturbance(vc, range, Phase.CN)))
+                .Concat(abPhaseDisturbanceRanges.Select(range => ToDisturbance(vab, range, Phase.AB)))
+                .Concat(bcPhaseDisturbanceRanges.Select(range => ToDisturbance(vbc, range, Phase.BC)))
+                .Concat(caPhaseDisturbanceRanges.Select(range => ToDisturbance(vca, range, Phase.CA)))
                 .ToList();
 
             IEnumerable<Range<int>> allDisturbanceRanges = aPhaseDisturbanceRanges
@@ -263,8 +302,7 @@ namespace FaultData.DataAnalysis
 
             disturbanceList.AddRange(worstDisturbances);
 
-            if (disturbanceList.Any())
-                m_disturbances.Add(dataGroup, disturbanceList);
+            return disturbanceList;
         }
 
         private DataSeries ToPerUnit(DataSeries rms)

--- a/Source/Libraries/FaultData/FaultData.csproj
+++ b/Source/Libraries/FaultData/FaultData.csproj
@@ -143,6 +143,7 @@
     <Compile Include="DataReaders\PQube\PQubeReader.cs" />
     <Compile Include="DataReaders\SELEVEReader.cs" />
     <Compile Include="DataResources\BreakerDataResource.cs" />
+    <Compile Include="DataResources\FastRMSDataResource.cs" />
     <Compile Include="DataResources\CycleDataResource.cs" />
     <Compile Include="DataResources\EventClassificationResource.cs" />
     <Compile Include="DataResources\DataGroupsResource.cs" />


### PR DESCRIPTION
After reviewing this code again, it seems like part of it did make it through the merge (see `FastRMSDataResource`), but these parts did not. It's possible that a bunch of it was reverted intentionally because it was loading data into the `EventData` table which is now deprecated.

@clackner-gpa I had thought that the fast RMS data was being associated with the corresponding instantaneous channels, but it seems they actually do end up with their own RMS channels in the database. The data group for the instantaneous data gets associated with the fast RMS data group later by the FastRMSDataResource. Therefore, it was possible after all to use the `ChannelData` table instead of introducing a new one.