### PR TITLE
Update HIDS to 1.0.5

### DIFF
--- a/Source/Applications/openXDA/openXDA/openXDA.csproj
+++ b/Source/Applications/openXDA/openXDA/openXDA.csproj
@@ -140,8 +140,8 @@
     <Reference Include="GSF.Web">
       <HintPath>..\..\..\Dependencies\GSF\GSF.Web.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.0.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Dependencies\NuGet\HIDS.1.0.4\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\Dependencies\NuGet\HIDS.1.0.5\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Applications/openXDA/openXDA/packages.config
+++ b/Source/Applications/openXDA/openXDA/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.1.0" targetFramework="net48" />
-  <package id="HIDS" version="1.0.4" targetFramework="net48" />
+  <package id="HIDS" version="1.0.5" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/Source/Libraries/OpenXDA.NotificationDataSources/HIDSDataSource.cs
+++ b/Source/Libraries/OpenXDA.NotificationDataSources/HIDSDataSource.cs
@@ -31,7 +31,6 @@ using System.Xml.Linq;
 using GSF;
 using GSF.Configuration;
 using GSF.Data;
-using GSF.Scheduling;
 using GSF.Xml;
 using HIDS;
 using openXDA.HIDS;
@@ -105,9 +104,12 @@ namespace openXDA.NotificationDataSources
 
             using (API hids = new API())
             {
-                hids.Configure(Settings.HIDSSettings);
-                Task influxQueryTask = QueryInfluxAsync(hids, xdaNow, doc);
-                influxQueryTask.GetAwaiter().GetResult();
+                Task queryTask = new Func<Task>(async () =>
+                {
+                    await hids.ConfigureAsync(Settings.HIDSSettings);
+                    await QueryInfluxAsync(hids, xdaNow, doc);
+                })();
+                queryTask.GetAwaiter().GetResult();
                 return xml;
             }
         }

--- a/Source/Libraries/OpenXDA.NotificationDataSources/openXDA.NotificationDataSources.csproj
+++ b/Source/Libraries/OpenXDA.NotificationDataSources/openXDA.NotificationDataSources.csproj
@@ -38,8 +38,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Dependencies\GSF\GSF.Core.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.0.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\HIDS.1.0.4\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\HIDS.1.0.5\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Libraries/OpenXDA.NotificationDataSources/packages.config
+++ b/Source/Libraries/OpenXDA.NotificationDataSources/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.1.0" targetFramework="net48" />
-  <package id="HIDS" version="1.0.4" targetFramework="net48" />
+  <package id="HIDS" version="1.0.5" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/Source/Libraries/SPCTools/SPCTools.csproj
+++ b/Source/Libraries/SPCTools/SPCTools.csproj
@@ -37,8 +37,8 @@
     <Reference Include="GSF.Core">
       <HintPath>..\..\Dependencies\GSF\GSF.Core.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.0.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\HIDS.1.0.4\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\HIDS.1.0.5\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Libraries/SPCTools/WizardController.cs
+++ b/Source/Libraries/SPCTools/WizardController.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Web.Http;
 using GSF.Data;
 using GSF.Data.Model;
@@ -350,9 +351,15 @@ namespace SPCTools
             List<Point> data;
             using (API hids = new API())
             {
-                HIDSSettings settings = SettingsHelper.GetHIDSSettings(Host);
-                hids.Configure(settings);
-                data = hids.ReadPointsAsync(dataToGet, start, end).ToListAsync().Result;
+                async Task<List<Point>> QueryHIDSAsync()
+                {
+                    HIDSSettings settings = SettingsHelper.GetHIDSSettings(Host);
+                    await hids.ConfigureAsync(settings);
+                    return await hids.ReadPointsAsync(dataToGet, start, end).ToListAsync();
+                }
+
+                Task<List<Point>> queryTask = QueryHIDSAsync();
+                data = queryTask.GetAwaiter().GetResult();
             }
 
             return channelID.ToDictionary(item => item, item => data.Where(pt => pt.Tag == item.ToString("x8")).ToList());

--- a/Source/Libraries/SPCTools/packages.config
+++ b/Source/Libraries/SPCTools/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.1.0" targetFramework="net48" />
-  <package id="HIDS" version="1.0.4" targetFramework="net48" />
+  <package id="HIDS" version="1.0.5" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/Source/Libraries/openXDA.Adapters/HIDSController.cs
+++ b/Source/Libraries/openXDA.Adapters/HIDSController.cs
@@ -145,7 +145,7 @@ namespace openXDA.Adapters
             MediaTypeHeaderValue contentType = new MediaTypeHeaderValue("text/plain");
             contentType.CharSet = "utf-8";
 
-            Stream pointStream = PointStream.QueryPoints(CreateHIDSConnection, BuildQuery);
+            Stream pointStream = PointStream.QueryPoints(CreateHIDSConnectionAsync, BuildQuery);
             StreamContent content = new StreamContent(pointStream);
             content.Headers.ContentType = contentType;
 
@@ -170,7 +170,7 @@ namespace openXDA.Adapters
 
             async Task<List<Point>> QueryHIDSAsync()
             {
-                using (API hids = CreateHIDSConnection())
+                using (API hids = await CreateHIDSConnectionAsync())
                 {
                     IEnumerable<string> tags = table
                         .AsEnumerable()
@@ -238,14 +238,14 @@ namespace openXDA.Adapters
             return response;
         }
 
-        private API CreateHIDSConnection()
+        private async Task<API> CreateHIDSConnectionAsync()
         {
             ConfigurationLoader configurationLoader = new ConfigurationLoader(Host.ID, Host.CreateDbConnection);
             Settings settings = new Settings();
             configurationLoader.Configure(settings);
 
             API hids = new API();
-            hids.Configure(settings.HIDSSettings);
+            await hids.ConfigureAsync(settings.HIDSSettings);
             return hids;
         }
 

--- a/Source/Libraries/openXDA.Adapters/TrendingDataDisplayController.cs
+++ b/Source/Libraries/openXDA.Adapters/TrendingDataDisplayController.cs
@@ -35,7 +35,6 @@ using GSF.Data;
 using GSF.Data.Model;
 using GSF.Web;
 using HIDS;
-using openHistorian.XDALink;
 using openXDA.Model;
 
 namespace openXDA.Adapters
@@ -287,28 +286,28 @@ namespace openXDA.Adapters
             using (AdoDataConnection connection = ConnectionFactory())
             using (API hids = new API())
             {
-
                 string host = connection.ExecuteScalar<string>("SELECT Value FROM Setting WHERE Name = 'HIDS.Host'") ?? "127.0.0.1";
                 string tokenID = connection.ExecuteScalar<string>("SELECT Value FROM Setting WHERE Name = 'HIDS.TokenID'") ?? "";
                 string pointBucket = connection.ExecuteScalar<string>("SELECT Value FROM Setting WHERE Name = 'HIDS.PointBucket'") ?? "point_bucket";
                 string orgID = connection.ExecuteScalar<string>("SELECT Value FROM Setting WHERE Name = 'HIDS.OrganizationID'") ?? "gpa";
 
-
-                hids.TokenID = tokenID;
-                hids.PointBucket = pointBucket;
-                hids.OrganizationID = orgID;
-                hids.Connect(host);
-
-
-                List<Point> points = hids.ReadPointsAsync((t) =>
+                async Task<List<Point>> QueryAsync()
                 {
-                    t.FilterTags(channelID.ToString("x8"));
-                    t.Range(startDate, endDate);
-                }).ToListAsync().Result;
+                    hids.TokenID = tokenID;
+                    hids.PointBucket = pointBucket;
+                    hids.OrganizationID = orgID;
+                    await hids.ConnectAsync(host);
 
-                return points;
+                    return await hids.ReadPointsAsync((t) =>
+                    {
+                        t.FilterTags(channelID.ToString("x8"));
+                        t.Range(startDate, endDate);
+                    }).ToListAsync();
+                }
+
+                Task<List<Point>> queryTask = QueryAsync();
+                return queryTask.GetAwaiter().GetResult();
             }
-
         }
 
         private IEnumerable<Point> QueryHIDS(IEnumerable<int> channels, DateTime startDate, DateTime endDate)
@@ -316,28 +315,28 @@ namespace openXDA.Adapters
             using (AdoDataConnection connection = ConnectionFactory())
             using (API hids = new API())
             {
-
                 string host = connection.ExecuteScalar<string>("SELECT Value FROM Setting WHERE Name = 'HIDS.Host'") ?? "127.0.0.1";
                 string tokenID = connection.ExecuteScalar<string>("SELECT Value FROM Setting WHERE Name = 'HIDS.TokenID'") ?? "";
                 string pointBucket = connection.ExecuteScalar<string>("SELECT Value FROM Setting WHERE Name = 'HIDS.PointBucket'") ?? "point_bucket";
                 string orgID = connection.ExecuteScalar<string>("SELECT Value FROM Setting WHERE Name = 'HIDS.OrganizationID'") ?? "gpa";
 
-
-                hids.TokenID = tokenID;
-                hids.PointBucket = pointBucket;
-                hids.OrganizationID = orgID;
-                hids.Connect(host);
-
-
-                List<Point> points = hids.ReadPointsAsync((t) =>
+                async Task<List<Point>> QueryAsync()
                 {
-                    t.FilterTags(channels.Select(c => c.ToString("x8")));
-                    t.Range(startDate, endDate);
-                }).ToListAsync().Result;
+                    hids.TokenID = tokenID;
+                    hids.PointBucket = pointBucket;
+                    hids.OrganizationID = orgID;
+                    await hids.ConnectAsync(host);
 
-                return points;
+                    return await hids.ReadPointsAsync((t) =>
+                    {
+                        t.FilterTags(channels.Select(c => c.ToString("x8")));
+                        t.Range(startDate, endDate);
+                    }).ToListAsync();
+                }
+
+                Task<List<Point>> queryTask = QueryAsync();
+                return queryTask.GetAwaiter().GetResult();
             }
-
         }
 
         #endregion

--- a/Source/Libraries/openXDA.Adapters/openXDA.Adapters.csproj
+++ b/Source/Libraries/openXDA.Adapters/openXDA.Adapters.csproj
@@ -43,8 +43,8 @@
     <Reference Include="GSF.Web">
       <HintPath>..\..\Dependencies\GSF\GSF.Web.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.0.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\HIDS.1.0.4\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\HIDS.1.0.5\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Libraries/openXDA.Adapters/packages.config
+++ b/Source/Libraries/openXDA.Adapters/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.1.0" targetFramework="net48" />
-  <package id="HIDS" version="1.0.4" targetFramework="net48" />
+  <package id="HIDS" version="1.0.5" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/Source/Libraries/openXDA.HIDS/APIExtensions/APIExtensions.cs
+++ b/Source/Libraries/openXDA.HIDS/APIExtensions/APIExtensions.cs
@@ -22,13 +22,14 @@
 //******************************************************************************************************
 
 using System;
+using System.Threading.Tasks;
 using HIDS;
 
 namespace openXDA.HIDS.APIExtensions
 {
     public static class APIExtensions
     {
-        public static void Configure(this API hids, HIDSSettings settings)
+        public static async Task ConfigureAsync(this API hids, HIDSSettings settings)
         {
             if (string.IsNullOrEmpty(settings.Host))
                 throw new ArgumentException("Unable to configure connection to HIDS: Host not specified.", nameof(settings));
@@ -42,7 +43,7 @@ namespace openXDA.HIDS.APIExtensions
             if (!string.IsNullOrEmpty(settings.OrganizationID))
                 hids.OrganizationID = settings.OrganizationID;
 
-            hids.Connect(settings.Host);
+            await hids.ConnectAsync(settings.Host);
         }
 
         public static string ToTag(this API _, int channelID) =>

--- a/Source/Libraries/openXDA.HIDS/HIDSAlarmOperation.cs
+++ b/Source/Libraries/openXDA.HIDS/HIDSAlarmOperation.cs
@@ -314,7 +314,8 @@ namespace openXDA.HIDS
             }
 
             using API hids = new API();
-            hids.Configure(HIDSSettings);
+            Task configureTask = hids.ConfigureAsync(HIDSSettings);
+            configureTask.GetAwaiter().GetResult();
 
             CountAlarms(channelTestersLookup, meterDataSet, connection, hids);
             LogAlarms(channelTestersLookup, meterDataSet, connection, hids);

--- a/Source/Libraries/openXDA.HIDS/PointAggregationResource.cs
+++ b/Source/Libraries/openXDA.HIDS/PointAggregationResource.cs
@@ -82,7 +82,7 @@ namespace openXDA.HIDS
             Dictionary<Channel, List<DataGroup>> trendingGroups = trendingGroupsResource.TrendingGroups;
 
             using API hids = new API();
-            hids.Configure(HIDSSettings);
+            await hids.ConfigureAsync(HIDSSettings);
 
             IEnumerable<string> tags = meterDataSet.Meter.Channels
                 .Where(channel => channel.Enabled)

--- a/Source/Libraries/openXDA.HIDS/TrendingDataSummaryOperation.cs
+++ b/Source/Libraries/openXDA.HIDS/TrendingDataSummaryOperation.cs
@@ -83,7 +83,8 @@ namespace openXDA.HIDS
             }
 
             using API hids = new API();
-            hids.Configure(HIDSSettings);
+            Task configureTask = hids.ConfigureAsync(HIDSSettings);
+            configureTask.GetAwaiter().GetResult();
 
             using AdoDataConnection connection = meterDataSet.CreateDbConnection();
 

--- a/Source/Libraries/openXDA.HIDS/openXDA.HIDS.csproj
+++ b/Source/Libraries/openXDA.HIDS/openXDA.HIDS.csproj
@@ -38,8 +38,8 @@
     <Reference Include="GSF.Core">
       <HintPath>..\..\Dependencies\GSF\GSF.Core.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.0.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\HIDS.1.0.4\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\HIDS.1.0.5\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Libraries/openXDA.HIDS/packages.config
+++ b/Source/Libraries/openXDA.HIDS/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.1.0" targetFramework="net48" />
-  <package id="HIDS" version="1.0.4" targetFramework="net48" />
+  <package id="HIDS" version="1.0.5" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />


### PR DESCRIPTION
This update should help prevent the service from hanging indefinitely due to multiple long timeouts and retries when attempting to store trending data while the InfluxDB server is unreachable.