### PR TITLE
Capture reported fault voltage/current from SEL COMTRADE/CEV files

### DIFF
--- a/Source/Libraries/FaultData/DataOperations/EventOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/EventOperation.cs
@@ -95,7 +95,7 @@ namespace FaultData.DataOperations
                 LoadEvents(connection, events, meterDataSet, processedDataGroups);
             }
 
-            LoadReportedEventType(meterDataSet);
+            LoadReportedAnalysis(meterDataSet);
         }
 
         private void FilterProcessedDataGroups(MeterDataSet meterDataSet)
@@ -342,19 +342,94 @@ namespace FaultData.DataOperations
             }
         }
 
-        private void LoadReportedEventType(MeterDataSet meterDataSet)
+        private void LoadReportedAnalysis(MeterDataSet meterDataSet)
         {
-            AnalysisDataSet faultLocationDataSet = meterDataSet.AnalysisDataSet;
-            string eventType = faultLocationDataSet?.EventType;
+            AnalysisDataSet analysisDataSet = meterDataSet.AnalysisDataSet;
 
-            if (string.IsNullOrWhiteSpace(eventType))
+            if (analysisDataSet is null)
                 return;
 
             using (AdoDataConnection connection = meterDataSet.CreateDbConnection())
             {
-                const string FieldName = "EventType";
-                const string Description = "Type of event as determined by the meter.";
-                meterDataSet.FileGroup.AddOrUpdateFieldValue(connection, FieldName, eventType, Description);
+                if (!string.IsNullOrEmpty(analysisDataSet.EventType))
+                {
+                    const string FieldName = "EventType";
+                    const string Description = "Type of event as determined by the meter.";
+                    string eventType = analysisDataSet.EventType;
+                    meterDataSet.FileGroup.AddOrUpdateFieldValue(connection, FieldName, eventType, Description);
+                }
+
+                if (!double.IsNaN(analysisDataSet.VA))
+                {
+                    const string FieldName = "VAFault";
+                    const string Description = "A-phase fault voltage as reported by the meter.";
+                    double va = analysisDataSet.VA;
+                    meterDataSet.FileGroup.AddOrUpdateFieldValue(connection, FieldName, va.ToString(), Description);
+                }
+
+                if (!double.IsNaN(analysisDataSet.VB))
+                {
+                    const string FieldName = "VBFault";
+                    const string Description = "B-phase fault voltage as reported by the meter.";
+                    double vb = analysisDataSet.VB;
+                    meterDataSet.FileGroup.AddOrUpdateFieldValue(connection, FieldName, vb.ToString(), Description);
+                }
+
+                if (!double.IsNaN(analysisDataSet.VC))
+                {
+                    const string FieldName = "VCFault";
+                    const string Description = "C-phase fault voltage as reported by the meter.";
+                    double vc = analysisDataSet.VC;
+                    meterDataSet.FileGroup.AddOrUpdateFieldValue(connection, FieldName, vc.ToString(), Description);
+                }
+
+                if (!double.IsNaN(analysisDataSet.IA))
+                {
+                    const string FieldName = "IAFault";
+                    const string Description = "A-phase fault current as reported by the meter.";
+                    double ia = analysisDataSet.IA;
+                    meterDataSet.FileGroup.AddOrUpdateFieldValue(connection, FieldName, ia.ToString(), Description);
+                }
+
+                if (!double.IsNaN(analysisDataSet.IB))
+                {
+                    const string FieldName = "IBFault";
+                    const string Description = "B-phase fault current as reported by the meter.";
+                    double ib = analysisDataSet.IB;
+                    meterDataSet.FileGroup.AddOrUpdateFieldValue(connection, FieldName, ib.ToString(), Description);
+                }
+
+                if (!double.IsNaN(analysisDataSet.IC))
+                {
+                    const string FieldName = "ICFault";
+                    const string Description = "C-phase fault current as reported by the meter.";
+                    double ic = analysisDataSet.IC;
+                    meterDataSet.FileGroup.AddOrUpdateFieldValue(connection, FieldName, ic.ToString(), Description);
+                }
+
+                if (!double.IsNaN(analysisDataSet.IN))
+                {
+                    const string FieldName = "INFault";
+                    const string Description = "Neutral fault current as reported by the meter.";
+                    double neutralCurrent = analysisDataSet.IN;
+                    meterDataSet.FileGroup.AddOrUpdateFieldValue(connection, FieldName, neutralCurrent.ToString(), Description);
+                }
+
+                if (!double.IsNaN(analysisDataSet.IG))
+                {
+                    const string FieldName = "IGFault";
+                    const string Description = "Ground fault current as reported by the meter.";
+                    double ig = analysisDataSet.IG;
+                    meterDataSet.FileGroup.AddOrUpdateFieldValue(connection, FieldName, ig.ToString(), Description);
+                }
+
+                if (!double.IsNaN(analysisDataSet.INeg3))
+                {
+                    const string FieldName = "3I2Fault";
+                    const string Description = "Tripled negative sequence fault current as reported by the meter.";
+                    double iNeg3 = analysisDataSet.INeg3;
+                    meterDataSet.FileGroup.AddOrUpdateFieldValue(connection, FieldName, iNeg3.ToString(), Description);
+                }
             }
         }
 

--- a/Source/Libraries/FaultData/DataReaders/SELEVEReader.cs
+++ b/Source/Libraries/FaultData/DataReaders/SELEVEReader.cs
@@ -196,6 +196,25 @@ namespace FaultData.DataReaders
                 if (!double.IsNaN(report.Location))
                     analysisDataSet.FaultLocation = report.Location;
 
+                if (!double.IsNaN(report.VA))
+                    analysisDataSet.VA = report.VA;
+                if (!double.IsNaN(report.VB))
+                    analysisDataSet.VB = report.VB;
+                if (!double.IsNaN(report.VC))
+                    analysisDataSet.VC = report.VC;
+                if (!double.IsNaN(report.IA))
+                    analysisDataSet.IA = report.IA;
+                if (!double.IsNaN(report.IB))
+                    analysisDataSet.IB = report.IB;
+                if (!double.IsNaN(report.IC))
+                    analysisDataSet.IC = report.IC;
+                if (!double.IsNaN(report.IG))
+                    analysisDataSet.IG = report.IG;
+                if (!double.IsNaN(report.IN))
+                    analysisDataSet.IN = report.IN;
+                if (!double.IsNaN(report.INeg3))
+                    analysisDataSet.INeg3 = report.INeg3;
+
                 for (int i = 0; i < report.AnalogSection.AnalogChannels.Count; i++)
                 {
                     Channel channel = MakeParsedAnalog(report, i);

--- a/Source/Libraries/FaultData/DataSets/AnalysisDataSet.cs
+++ b/Source/Libraries/FaultData/DataSets/AnalysisDataSet.cs
@@ -27,5 +27,14 @@ namespace FaultData.DataSets
     {
         public string EventType { get; set; }
         public double FaultLocation { get; set; } = double.NaN;
+        public double VA { get; set; } = double.NaN;
+        public double VB { get; set; } = double.NaN;
+        public double VC { get; set; } = double.NaN;
+        public double IA { get; set; } = double.NaN;
+        public double IB { get; set; } = double.NaN;
+        public double IC { get; set; } = double.NaN;
+        public double IG { get; set; } = double.NaN;
+        public double IN { get; set; } = double.NaN;
+        public double INeg3 { get; set; } = double.NaN;
     }
 }


### PR DESCRIPTION
For SDG&E requirements...

* Parse HDR files from COMTRADE records produced by SEL devices to retrieve fault voltage/current as recorded by the device.
* Copy values parsed from the COMTRADE header file and the CEV file headers to the `AnalysisDataSet`.
* Dump fault voltage/current values from the `AnalysisDataSet` into the `FileGroupFieldValue` table.

Example COMTRADE header file...

```text

GM 1234 BUS SEL-351            Date: 01/07/23    Time: 16:02:52.174
GARREG MACH

Event: CG         Location: $$$$$$$            Trip Time: --:--:--.---
#: 12345  Shot:    Freq:  60.00  Group: 1     Close Time: --:--:--.---
Targets: 
Breaker: Closed

PreFault:     IA     IB     IC     IN     IG    3I2       VA       VB       VC
MAG(A/kV)    124    132    142     14     16     16    6.953    6.951    6.956
ANG(DEG)   19.31-100.44 138.96 167.47 165.29-131.91     0.00  -119.70   120.00
Fault:
MAG(A/kV)    166    190   1080   1028   1028   1072    7.177    7.073    6.159
ANG(DEG)   10.33-105.95  56.79  46.87  46.91 167.59    -2.50  -117.39   118.35

...
```