### PR TITLE
Introduce error handling into PQI queries used by EventOperation

### DIFF
--- a/Source/Libraries/FaultData/DataOperations/EventOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/EventOperation.cs
@@ -583,12 +583,19 @@ namespace FaultData.DataOperations
                 return pingClient.AccessToken;
             }
 
-            PQIWSClient pqiwsClient = new PQIWSClient(PQISettings.BaseURL, FetchAccessToken);
-            PQIWSQueryHelper pqiwsQueryHelper = new PQIWSQueryHelper(meterDataSet.CreateDbConnection, pqiwsClient);
-            Task<bool> queryTask = pqiwsQueryHelper.HasImpactedComponentsAsync(evt.ID);
+            try
+            {
+                PQIWSClient pqiwsClient = new PQIWSClient(PQISettings.BaseURL, FetchAccessToken);
+                PQIWSQueryHelper pqiwsQueryHelper = new PQIWSQueryHelper(meterDataSet.CreateDbConnection, pqiwsClient);
+                Task<bool> queryTask = pqiwsQueryHelper.HasImpactedComponentsAsync(evt.ID);
 
-            if (queryTask.GetAwaiter().GetResult())
-                connection.ExecuteNonQuery("INSERT INTO PQIResult VALUES ({0})", evt.ID);
+                if (queryTask.GetAwaiter().GetResult())
+                    connection.ExecuteNonQuery("INSERT INTO PQIResult VALUES ({0})", evt.ID);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message, ex);
+            }
         }
 
         private double ToDbFloat(double value)


### PR DESCRIPTION
If the PQI service is unavailable, `EventOperation` will fail after writing the first event to the database and subsequent events will not be written. This introduces error handling to log the PQI error and continue writing events.