### PR TITLE
Fix various compiler warnings

### DIFF
--- a/Source/Applications/openXDA/openXDA/Web.config
+++ b/Source/Applications/openXDA/openXDA/Web.config
@@ -40,7 +40,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/Source/Applications/openXDA/openXDA/openXDA.csproj
+++ b/Source/Applications/openXDA/openXDA/openXDA.csproj
@@ -102,10 +102,6 @@
     <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject>
-    </StartupObject>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Antlr3.Runtime">
       <HintPath>..\..\..\Dependencies\GSF\Antlr3.Runtime.dll</HintPath>
@@ -275,8 +271,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Caching" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.Security.AccessControl, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -312,8 +308,8 @@
       <HintPath>..\..\..\Dependencies\NuGet\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Transactions" />
-    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Dependencies\NuGet\System.ValueTuple.4.4.0\lib\net47\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\Dependencies\NuGet\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Source/Applications/openXDA/openXDA/packages.config
+++ b/Source/Applications/openXDA/openXDA/packages.config
@@ -33,7 +33,7 @@
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Reactive" version="5.0.0" targetFramework="net48" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
   <package id="System.Security.AccessControl" version="6.0.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
@@ -42,5 +42,5 @@
   <package id="System.Security.Permissions" version="5.0.0" targetFramework="net48" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/Source/Libraries/OpenXDA.NotificationDataSources/openXDA.NotificationDataSources.csproj
+++ b/Source/Libraries/OpenXDA.NotificationDataSources/openXDA.NotificationDataSources.csproj
@@ -110,8 +110,8 @@
     <Reference Include="System.Reactive, Version=5.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\System.Reactive.5.0.0\lib\net472\System.Reactive.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.Security.AccessControl, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Source/Libraries/OpenXDA.NotificationDataSources/packages.config
+++ b/Source/Libraries/OpenXDA.NotificationDataSources/packages.config
@@ -22,7 +22,7 @@
   <package id="System.Memory" version="4.5.4" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Reactive" version="5.0.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
   <package id="System.Security.AccessControl" version="6.0.0" targetFramework="net48" />
   <package id="System.Security.Permissions" version="5.0.0" targetFramework="net48" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net48" />

--- a/Source/Libraries/PQDS/MetaDataTag.cs
+++ b/Source/Libraries/PQDS/MetaDataTag.cs
@@ -35,10 +35,30 @@ namespace PQDS
     /// </summary>
     public enum PQDSMetaDataType
     {
+        /// <summary>
+        /// An integer representing a single value selected
+        /// from among a custom, finite set of possibilities
+        /// </summary>
         Enumeration = 0,
+
+        /// <summary>
+        /// A number
+        /// </summary>
         Numeric = 1,
+
+        /// <summary>
+        /// Text consisting only of alphabetical characters and digits
+        /// </summary>
         AlphaNumeric = 2,
+
+        /// <summary>
+        /// Freeform text
+        /// </summary>
         Text = 3,
+
+        /// <summary>
+        /// A Boolean value (true/false)
+        /// </summary>
         Binary = 4
 
     }
@@ -50,9 +70,24 @@ namespace PQDS
     {
         #region[Properties]
 
+        /// <summary>
+        /// The key that identifies the metadata tag.
+        /// </summary>
         protected string m_key;
+
+        /// <summary>
+        /// The unit of measurement.
+        /// </summary>
         protected string m_unit;
+
+        /// <summary>
+        /// The data type the parser expects to encounter for the value of the metdata.
+        /// </summary>
         protected PQDSMetaDataType m_expectedDataType;
+
+        /// <summary>
+        /// Additional notes about the metadata field.
+        /// </summary>
         protected string m_note;
 
         #endregion[Properties]

--- a/Source/Libraries/PQDS/PQDSFile.cs
+++ b/Source/Libraries/PQDS/PQDSFile.cs
@@ -287,7 +287,7 @@ namespace PQDS
         /// Writes the content to a .csv file.
         /// </summary>
         /// <param name="stream"> The <see cref="StreamWriter"/> to write the data to. </param>
-        /// <param name="progress"> <see cref="IProgress"/> Progress Token</param>
+        /// <param name="progress"> <see cref="IProgress{T}"/> Progress Token</param>
         public void WriteToStream(StreamWriter stream, IProgress<double> progress)
         {
             int n_data = this.Data.Select((item) => item.Length).Max();
@@ -312,7 +312,7 @@ namespace PQDS
         /// Writes the content to a .csv file.
         /// </summary>
         /// <param name="file"> file name </param>
-        /// <param name="progress"> <see cref="IProgress"/> Progress Token</param>
+        /// <param name="progress"> <see cref="IProgress{T}"/> Progress Token</param>
         public void WriteToFile(string file, IProgress<double> progress)
         {
             // Open the file and write in each line
@@ -359,7 +359,7 @@ namespace PQDS
         /// Reads the content from a PQDS File.
         /// </summary>
         /// <param name="filename"> file name</param>
-        /// <param name="progress"> <see cref="IProgress"/> Progress Token </param>
+        /// <param name="progress"> <see cref="IProgress{T}"/> Progress Token </param>
         public void ReadFromFile(string filename, IProgress<double> progress)
         {
             List<string> lines = new List<string>();

--- a/Source/Libraries/SPCTools/SPCTools.csproj
+++ b/Source/Libraries/SPCTools/SPCTools.csproj
@@ -108,14 +108,8 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Net.Http.Formatting.Extension.5.2.3.0\lib\System.Net.Http.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Net.Http.Formatting.Extension.5.2.3.0\lib\System.Net.Http.Formatting.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Net.Http.Formatting.Extension.5.2.3.0\lib\System.Net.Http.Primitives.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\Microsoft.AspNet.WebApi.Client.5.2.4\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -130,8 +124,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Caching" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.Security.AccessControl, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -177,8 +171,8 @@
       <HintPath>..\..\Dependencies\NuGet\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Transactions" />
-    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.ValueTuple.4.4.0\lib\net47\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Http">

--- a/Source/Libraries/SPCTools/packages.config
+++ b/Source/Libraries/SPCTools/packages.config
@@ -5,6 +5,7 @@
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.HashCode" version="1.1.1" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net48" />
@@ -22,11 +23,10 @@
   <package id="System.Linq.Async" version="4.1.1" targetFramework="net48" />
   <package id="System.Memory" version="4.5.4" targetFramework="net48" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net48" />
-  <package id="System.Net.Http.Formatting.Extension" version="5.2.3.0" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Reactive" version="5.0.0" targetFramework="net48" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
   <package id="System.Security.AccessControl" version="6.0.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
@@ -35,5 +35,5 @@
   <package id="System.Security.Permissions" version="5.0.0" targetFramework="net48" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/Source/Libraries/openXDA.Adapters/OpenSEECSVDownload.ashx.cs
+++ b/Source/Libraries/openXDA.Adapters/OpenSEECSVDownload.ashx.cs
@@ -263,9 +263,10 @@ namespace openXDA.Adapters
             }
         }
 
-        private class PhasorResult {
-            public double Magnitude;
-            public double Angle;
+        private class PhasorResult
+        {
+            public double Magnitude { get; set; }
+            public double Angle { get; set; }
         }
 
         public void ExportHarmonicsToCSV(Stream returnStream, NameValueCollection requestParameters)

--- a/Source/Libraries/openXDA.Adapters/openXDA.Adapters.csproj
+++ b/Source/Libraries/openXDA.Adapters/openXDA.Adapters.csproj
@@ -125,8 +125,8 @@
       <HintPath>..\..\Dependencies\NuGet\System.Reactive.5.0.0\lib\net472\System.Reactive.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Caching" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />

--- a/Source/Libraries/openXDA.Adapters/packages.config
+++ b/Source/Libraries/openXDA.Adapters/packages.config
@@ -25,7 +25,7 @@
   <package id="System.Memory" version="4.5.4" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Reactive" version="5.0.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
   <package id="System.Security.AccessControl" version="6.0.0" targetFramework="net48" />
   <package id="System.Security.Permissions" version="5.0.0" targetFramework="net48" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net48" />

--- a/Source/Libraries/openXDA.DataPusher/WebAPIHub.cs
+++ b/Source/Libraries/openXDA.DataPusher/WebAPIHub.cs
@@ -316,7 +316,7 @@ namespace openXDA.DataPusher
                         return response.IsSuccessStatusCode;
                     }
                 }
-                catch (Exception ex) //Exception here is a fail state, must be caught reported back so that testers know the failpoint is downstream
+                catch //Exception here is a fail state, must be caught reported back so that testers know the failpoint is downstream
                 {
                     return false;
                 }

--- a/Source/Libraries/openXDA.HIDS/openXDA.HIDS.csproj
+++ b/Source/Libraries/openXDA.HIDS/openXDA.HIDS.csproj
@@ -124,8 +124,8 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.Security.AccessControl, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -171,8 +171,8 @@
       <HintPath>..\..\Dependencies\NuGet\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Transactions" />
-    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.ValueTuple.4.4.0\lib\net47\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Windows" />

--- a/Source/Libraries/openXDA.HIDS/packages.config
+++ b/Source/Libraries/openXDA.HIDS/packages.config
@@ -26,7 +26,7 @@
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Reactive" version="5.0.0" targetFramework="net48" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
   <package id="System.Security.AccessControl" version="6.0.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net48" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
@@ -35,5 +35,5 @@
   <package id="System.Security.Permissions" version="5.0.0" targetFramework="net48" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/Source/Libraries/openXDA.Model/Meters/Meter.cs
+++ b/Source/Libraries/openXDA.Model/Meters/Meter.cs
@@ -330,7 +330,7 @@ namespace openXDA.Model
     public class MeterDetail : Meter
     {
         [Searchable]
-        public string Location { get; set; }
+        public new string Location { get; set; }
 
         public string TimeZoneLabel
         {

--- a/Source/Tools/XDABatchDataTransferTool/App.config
+++ b/Source/Tools/XDABatchDataTransferTool/App.config
@@ -15,7 +15,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />


### PR DESCRIPTION
This fixes most of the compiler warnings I saw when building the project in Visual Studio 2022. Nearly all of them were dll version mismatch warnings due to different versions of assemblies being referenced by HIDS versus GSF. The rest are hopefully pretty self-explanatory, like missing XML comments or unused variables.