### PR TITLE
Config file cleanup

### DIFF
--- a/Source/Applications/openXDA/openXDA/App.config
+++ b/Source/Applications/openXDA/openXDA/App.config
@@ -80,6 +80,8 @@
       <add name="EnableOfflineCaching" value="True" description="True to enable caching of user information for authentication in offline state, otherwise False." encrypted="false" />
       <add name="PasswordRequirementsRegex" value="^.*(?=.{8,})(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).*$" description="Regular expression used to validate new passwords for database users." encrypted="false" />
       <add name="PasswordRequirementsError" value="Invalid Password: Password must be at least 8 characters; must contain at least 1 number, 1 upper case letter, and 1 lower case letter" description="Error message to be displayed when new database user password fails regular expression test." encrypted="false" />
+      <add name="AzureADConfigSource" value="appsettings.json" description="Azure AD configuration source. Either 'appsettings.json' file path or settings category to use." encrypted="false" />
+      <add name="AzureADSecret" value="env(User:openXDASecretKey)" description="Defines the Azure AD secret value to be used for user info and group lookups, post authentication." encrypted="false" />
     </securityProvider>
   </categorizedSettings>
   <startup>

--- a/Source/Applications/openXDA/openXDA/App.config
+++ b/Source/Applications/openXDA/openXDA/App.config
@@ -1,96 +1,92 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<configSections>
-		<section name="categorizedSettings" type="GSF.Configuration.CategorizedSettingsSection, GSF.Core"/>
-	</configSections>
-	<categorizedSettings>
-		<systemSettings>
-		  <!-- *** MODIFY CONNECTION STRING AND DATA PROVIDER STRINGS BELOW *** -->
-			<add name="ConnectionString" value="Data Source=localhost; Initial Catalog=openXDA; Integrated Security=SSPI" description="Defines the connection to the openXDA database." encrypted="false"/>
-			<add name="DataProviderString" value="AssemblyName={System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089}; ConnectionType=System.Data.SqlClient.SqlConnection; AdapterType=System.Data.SqlClient.SqlDataAdapter" description="Configuration database ADO.NET data provider assembly type creation string used when ConfigurationType=Database" encrypted="false"/>
-		  <!-- **************************************************************** -->
-			<add name="NodeID" value="00000000-0000-0000-0000-000000000000" description="Unique Node ID" encrypted="false"/>
-			<add name="CompanyName" value="Grid Protection Alliance" description="The name of the company who owns this instance of openXDA." encrypted="false"/>
-			<add name="CompanyAcronym" value="GPA" description="The acronym representing the company who owns this instance of openXDA." encrypted="false"/>
-			<add name="DefaultCulture" value="en-US" description="Default culture to use for language, country/region and calendar formats." encrypted="false"/>
-			<add name="DateFormat" value="MM/dd/yyyy" description="The date format to use when rendering timestamps." encrypted="false"/>
-			<add name="TimeFormat" value="HH:mm.ss.fff" description="The time format to use when rendering timestamps." encrypted="false"/>
-      <add name="PQMarkUserName" value="username" description="User name for PQMarkWeb API access." encrypted="false"/>
-      <add name="PQMarkPassword" value="" description="Password for PQMarkWeb API access." encrypted="true"/>
-      <add name="CertFile" value="" description="Cert File for https." encrypted="false"/>
-      <add name="ValidPolicyErrors" value="None" description="SSL Policy flags." encrypted="false"/>
-      <add name="ValidChainFlags" value="NoError" description="X509 Chain Flags." encrypted="false"/>
-      <add name="SessionTimeout" value="20" description="The timeout, in minutes, for which inactive client sessions will be expired and removed from the cache." encrypted="false"/>
-      <add name="SessionMonitorInterval" value="60000" description="The interval, in milliseconds, over which the client session cache will be evaluated for expired sessions." encrypted="false"/>
-      <add name="ConfigurationCachePath" value="ConfigurationCache\" description="Defines the path used to cache serialized configurations" encrypted="false"/>
+  <configSections>
+    <section name="categorizedSettings" type="GSF.Configuration.CategorizedSettingsSection, GSF.Core" />
+  </configSections>
+  <categorizedSettings>
+    <systemSettings>
+      <!-- *** MODIFY CONNECTION STRING AND DATA PROVIDER STRINGS BELOW *** -->
+      <add name="ConnectionString" value="Data Source=localhost; Initial Catalog=openXDA; Integrated Security=SSPI" description="Defines the connection to the openXDA database." encrypted="false" />
+      <add name="DataProviderString" value="AssemblyName={System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089}; ConnectionType=System.Data.SqlClient.SqlConnection; AdapterType=System.Data.SqlClient.SqlDataAdapter" description="Configuration database ADO.NET data provider assembly type creation string used when ConfigurationType=Database" encrypted="false" />
+      <!-- **************************************************************** -->
+      <add name="NodeID" value="00000000-0000-0000-0000-000000000000" description="Unique Node ID" encrypted="false" />
+      <add name="CompanyName" value="Grid Protection Alliance" description="The name of the company who owns this instance of openXDA." encrypted="false" />
+      <add name="CompanyAcronym" value="GPA" description="The acronym representing the company who owns this instance of openXDA." encrypted="false" />
+      <add name="DefaultCulture" value="en-US" description="Default culture to use for language, country/region and calendar formats." encrypted="false" />
+      <add name="DateFormat" value="MM/dd/yyyy" description="The date format to use when rendering timestamps." encrypted="false" />
+      <add name="TimeFormat" value="HH:mm.ss.fff" description="The time format to use when rendering timestamps." encrypted="false" />
+      <add name="PQMarkUserName" value="username" description="User name for PQMarkWeb API access." encrypted="false" />
+      <add name="PQMarkPassword" value="" description="Password for PQMarkWeb API access." encrypted="true" />
+      <add name="CertFile" value="" description="Certificate for WebAPIHub used by PQMark/DataPusher." encrypted="false" />
+      <add name="ValidPolicyErrors" value="None" description="Expected policy errors during remote server certificate validation for PQMark/DataPusher (self-signed: RemoteCertificateNameMismatch, RemoteCertificateChainErrors)." encrypted="false" />
+      <add name="ValidChainFlags" value="NoError" description="Expected chain flags set during remote server certificate validation for PQMark/DataPusher (self-signed: UntrustedRoot)." encrypted="false" />
+      <add name="SessionTimeout" value="20" description="The timeout, in minutes, for which inactive client sessions will be expired and removed from the cache." encrypted="false" />
+      <add name="SessionMonitorInterval" value="60000" description="The interval, in milliseconds, over which the client session cache will be evaluated for expired sessions." encrypted="false" />
+      <add name="ConfigurationCachePath" value="ConfigurationCache\" description="Defines the path used to cache serialized configurations" encrypted="false" />
 
       <!-- Necessary because of how razor engine for embedded resources works -->
       <!-- Note that changes to the value of this setting require the service to be restarted -->
-      <add name="EmbeddedTemplatePath" value="Eval(webHost.EmbeddedTemplatePath)" description="Embedded name space path for data context based razor field templates." encrypted="false"/>
+      <add name="EmbeddedTemplatePath" value="Eval(webHost.EmbeddedTemplatePath)" description="Embedded name space path for data context based razor field templates." encrypted="false" />
     </systemSettings>
     <webHost>
       <!-- Web host -->
-      <add name="WebHostURL" value="http://+:8989" description="The web hosting URL for remote system management." encrypted="false"/>
-      <add name="DefaultWebPage" value="index.cshtml" description="The default web page for the hosted web server." encrypted="false"/>
-      <add name="AllowedDomainList" value="*" description="Cross-domain access. Can have 1 domain or all domains. Use * for all domains and wildcards, e.g., *.consoto.com." encrypted="false"/>
-      
+      <add name="WebHostURL" value="http://+:8989" description="The web hosting URL for remote system management." encrypted="false" />
+      <add name="DefaultWebPage" value="index.cshtml" description="The default web page for the hosted web server." encrypted="false" />
+      <add name="AllowedDomainList" value="*" description="Cross-domain access. Can have 1 domain or all domains. Use * for all domains and wildcards, e.g., *.consoto.com." encrypted="false" />
+
       <!-- Web server -->
-      <add name="WebRootPath" value="wwwroot" description="The root path for the hosted web server files. Location will be relative to install folder if full path is not specified." encrypted="false"/>
-      <add name="ClientCacheEnabled" value="True" description="Determines if cache control is enabled for browser clients." encrypted="false"/>
-      <add name="MinifyStyleSheets" value="True" description="Determines if minification should be applied to rendered CSS files." encrypted="false"/>
-      <add name="UseMinifyInDebug" value="False" description="Determines if minification should be applied when running a Debug build." encrypted="false"/>
-      <add name="SessionToken" value="x-gsf-session" description="Defines the token used for identifying the session ID in cookie headers." encrypted="false"/>
-      <add name="AuthTestPage" value="/AuthTest" description="Defines the page name for the web server to test if a user is authenticated. Expects forward slash prefix." encrypted="false"/>
-      
+      <add name="WebRootPath" value="wwwroot" description="The root path for the hosted web server files. Location will be relative to install folder if full path is not specified." encrypted="false" />
+      <add name="ClientCacheEnabled" value="True" description="Determines if cache control is enabled for browser clients." encrypted="false" />
+      <add name="MinifyStyleSheets" value="True" description="Determines if minification should be applied to rendered CSS files." encrypted="false" />
+      <add name="UseMinifyInDebug" value="False" description="Determines if minification should be applied when running a Debug build." encrypted="false" />
+      <add name="SessionToken" value="x-gsf-session" description="Defines the token used for identifying the session ID in cookie headers." encrypted="false" />
+      <add name="AuthTestPage" value="/AuthTest" description="Defines the page name for the web server to test if a user is authenticated. Expects forward slash prefix." encrypted="false" />
+
       <!-- Razor engine -->
-      <add name="TemplatePath" value="Eval(webHost.WebRootPath)" description="Path for data context based razor field templates." encrypted="false"/>
-      <add name="EmbeddedTemplatePath" value="GSF.Web.Model.Views." description="Embedded name space path for data context based razor field templates." encrypted="false"/>
-      
+      <add name="TemplatePath" value="Eval(webHost.WebRootPath)" description="Path for data context based razor field templates." encrypted="false" />
+      <add name="EmbeddedTemplatePath" value="GSF.Web.Model.Views." description="Embedded name space path for data context based razor field templates." encrypted="false" />
+
       <!-- Authentication -->
-      <add name="AuthenticationSchemes" value="Ntlm, Basic" description="Comma separated list of authentication schemes to use for clients accessing the hosted web server, e.g., Basic or NTLM." encrypted="false"/>
-      <add name="AuthFailureRedirectResourceExpression" value="^/$|^/.+\.cshtml$|^/.+\.vbhtml$|^/grafana(?!/api/).*$|^/api/auth/logon?.*$" description="Expression that will match paths for the resources on the web server that should redirect to the LoginPage when authentication fails." encrypted="false"/>
-      <add name="AnonymousResourceExpression" value="^/@|^/Scripts/|^/Content/|^/Images/|^/fonts/|^/favicon.ico$|^/api/auth/token$" description="Expression that will match paths for the resources on the web server that can be provided without checking credentials." encrypted="false"/>
-      <add name="AuthenticationToken" value="x-gsf-auth" description="Defines the token used for identifying the authentication token in cookie headers." encrypted="false"/>
-      <!-- <add name="SessionToken" value="x-gsf-session" description="Defines the token used for identifying the session ID in cookie headers." encrypted="false"/> -->
-      <add name="RequestVerificationToken" value="X-GSF-Verify" description="Defines the token used for identifying the authentication token in cookie headers." encrypted="false"/>
-      <add name="LoginPage" value="/@GSF/Web/Security/Views/Login.cshtml" description="Defines the login page used for redirects on authentication failure. Expects forward slash prefix." encrypted="false"/>
-      <!-- <add name="AuthTestPage" value="/AuthTest" description="Defines the page name for the web server to test if a user is authenticated. Expects forward slash prefix." encrypted="false"/> -->
-      <add name="Realm" value="" description="Case-sensitive identifier that defines the protection space for the web based authentication and is used to indicate a scope of protection." encrypted="false"/>
-      
+      <add name="AuthenticationSchemes" value="Ntlm, Basic" description="Comma separated list of authentication schemes to use for clients accessing the hosted web server, e.g., Basic or NTLM." encrypted="false" />
+      <add name="AuthFailureRedirectResourceExpression" value="^/$|^/.+\.cshtml$|^/.+\.vbhtml$|^/grafana(?!/api/).*$|^/api/auth/logon?.*$" description="Expression that will match paths for the resources on the web server that should redirect to the LoginPage when authentication fails." encrypted="false" />
+      <add name="AnonymousResourceExpression" value="^/@|^/Scripts/|^/Content/|^/Images/|^/fonts/|^/favicon.ico$|^/api/auth/token$" description="Expression that will match paths for the resources on the web server that can be provided without checking credentials." encrypted="false" />
+      <add name="AuthenticationToken" value="x-gsf-auth" description="Defines the token used for identifying the authentication token in cookie headers." encrypted="false" />
+      <!-- <add name="SessionToken" value="x-gsf-session" description="Defines the token used for identifying the session ID in cookie headers." encrypted="false" /> -->
+      <add name="RequestVerificationToken" value="X-GSF-Verify" description="Defines the token used for identifying the authentication token in cookie headers." encrypted="false" />
+      <add name="LoginPage" value="/@GSF/Web/Security/Views/Login.cshtml" description="Defines the login page used for redirects on authentication failure. Expects forward slash prefix." encrypted="false" />
+      <!-- <add name="AuthTestPage" value="/AuthTest" description="Defines the page name for the web server to test if a user is authenticated. Expects forward slash prefix." encrypted="false" /> -->
+      <add name="Realm" value="" description="Case-sensitive identifier that defines the protection space for the web based authentication and is used to indicate a scope of protection." encrypted="false" />
+
       <!-- App model -->
-      <add name="CompanyName" value="Eval(systemSettings.CompanyName)" description="The name of the company who owns this instance of openXDA." encrypted="false"/>
-      <add name="CompanyAcronym" value="Eval(systemSettings.CompanyAcronym)" description="The acronym representing the company who owns this instance of openXDA." encrypted="false"/>
-      <add name="DateFormat" value="Eval(systemSettings.DateFormat)" description="The date format to use when rendering timestamps." encrypted="false"/>
-      <add name="TimeFormat" value="Eval(systemSettings.TimeFormat)" description="The time format to use when rendering timestamps." encrypted="false"/>
-      <add name="BootstrapTheme" value="Content/bootstrap-theme.min.css" description="Path to Bootstrap CSS to use for rendering styles." encrypted="false"/>
+      <add name="CompanyName" value="Eval(systemSettings.CompanyName)" description="The name of the company who owns this instance of openXDA." encrypted="false" />
+      <add name="CompanyAcronym" value="Eval(systemSettings.CompanyAcronym)" description="The acronym representing the company who owns this instance of openXDA." encrypted="false" />
+      <add name="DateFormat" value="Eval(systemSettings.DateFormat)" description="The date format to use when rendering timestamps." encrypted="false" />
+      <add name="TimeFormat" value="Eval(systemSettings.TimeFormat)" description="The time format to use when rendering timestamps." encrypted="false" />
+      <add name="BootstrapTheme" value="Content/bootstrap-theme.min.css" description="Path to Bootstrap CSS to use for rendering styles." encrypted="false" />
     </webHost>
-		<securityProvider>
-			<add name="ApplicationName" value="openXDA" description="Name of the application being secured as defined in the backend security datastore." encrypted="false"/>
-			<add name="ProviderType" value="GSF.Security.AdoSecurityProvider, GSF.Security" description="The type to be used for enforcing security." encrypted="false"/>
-			<add name="UserCacheTimeout" value="0" description="Defines the timeout, in whole minutes, for a user's provider cache. Any value less than 1 will cause cache reset every minute." encrypted="false"/>
-			<add name="IncludedResources" value="UpdateSettings,UpdateConfigFile=Special; Settings,Schedules,Help,Status,Version,Time,User,Health,List,Invoke,ListCommands,ListReports,GetReport=*; Processes,Start,ReloadCryptoCache,ReloadSettings,Reschedule,Unschedule,SaveSchedules,LoadSchedules,ResetHealthMonitor,Connect,Disconnect,Initialize,ReloadConfig,Authenticate,RefreshRoutes,TemporalSupport,LogEvent,GenerateReport,ReportingConfig=Administrator,Editor; *=Administrator" description="Semicolon delimited list of resources to be secured along with role names." encrypted="false"/>
-			<add name="ExcludedResources" value="" description="Semicolon delimited list of resources to be excluded from being secured." encrypted="false"/>
-			<add name="NotificationSmtpServer" value="localhost" description="SMTP server to be used for sending out email notification messages." encrypted="false"/>
-			<add name="NotificationSenderEmail" value="sender@company.com" description="Email address of the sender of email notification messages." encrypted="false"/>
-			<add name="ConnectionString" value="Eval(systemSettings.ConnectionString)" description="Connection connection string to be used for connection to the backend security datastore." encrypted="false"/>
-			<add name="DataProviderString" value="Eval(systemSettings.DataProviderString)" description="Configuration database ADO.NET data provider assembly type creation string to be used for connection to the backend security datastore." encrypted="false"/>
-			<add name="LdapPath" value="" description="Specifies the LDAP path used to initialize the security provider." encrypted="false"/>
-			<add name="CacheRetryDelayInterval" value="1000" description="Wait interval, in milliseconds, before retrying load of user data cache." encrypted="false"/>
-			<add name="CacheMaximumRetryAttempts" value="5" description="Maximum retry attempts allowed for loading user data cache." encrypted="false"/>
-			<add name="EnableOfflineCaching" value="True" description="True to enable caching of user information for authentication in offline state, otherwise False." encrypted="false"/>
-			<add name="PasswordRequirementsRegex" value="^.*(?=.{8,})(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).*$" description="Regular expression used to validate new passwords for database users." encrypted="false"/>
-			<add name="PasswordRequirementsError" value="Invalid Password: Password must be at least 8 characters; must contain at least 1 number, 1 upper case letter, and 1 lower case letter" description="Error message to be displayed when new database user password fails regular expression test." encrypted="false"/>
+    <securityProvider>
+      <add name="ApplicationName" value="openXDA" description="Name of the application being secured as defined in the backend security datastore." encrypted="false" />
+      <add name="ProviderType" value="GSF.Security.AdoSecurityProvider, GSF.Security" description="The type to be used for enforcing security." encrypted="false" />
+      <add name="UserCacheTimeout" value="0" description="Defines the timeout, in whole minutes, for a user's provider cache. Any value less than 1 will cause cache reset every minute." encrypted="false" />
+      <add name="IncludedResources" value="UpdateSettings,UpdateConfigFile=Special; Settings,Schedules,Help,Status,Version,Time,User,Health,List,Invoke,ListCommands,ListReports,GetReport=*; Processes,Start,ReloadCryptoCache,ReloadSettings,Reschedule,Unschedule,SaveSchedules,LoadSchedules,ResetHealthMonitor,Connect,Disconnect,Initialize,ReloadConfig,Authenticate,RefreshRoutes,TemporalSupport,LogEvent,GenerateReport,ReportingConfig=Administrator,Editor; *=Administrator" description="Semicolon delimited list of resources to be secured along with role names." encrypted="false" />
+      <add name="ExcludedResources" value="" description="Semicolon delimited list of resources to be excluded from being secured." encrypted="false" />
+      <add name="NotificationSmtpServer" value="localhost" description="SMTP server to be used for sending out email notification messages." encrypted="false" />
+      <add name="NotificationSenderEmail" value="sender@company.com" description="Email address of the sender of email notification messages." encrypted="false" />
+      <add name="ConnectionString" value="Eval(systemSettings.ConnectionString)" description="Connection connection string to be used for connection to the backend security datastore." encrypted="false" />
+      <add name="DataProviderString" value="Eval(systemSettings.DataProviderString)" description="Configuration database ADO.NET data provider assembly type creation string to be used for connection to the backend security datastore." encrypted="false" />
+      <add name="LdapPath" value="" description="Specifies the LDAP path used to initialize the security provider." encrypted="false" />
+      <add name="CacheRetryDelayInterval" value="1000" description="Wait interval, in milliseconds, before retrying load of user data cache." encrypted="false" />
+      <add name="CacheMaximumRetryAttempts" value="5" description="Maximum retry attempts allowed for loading user data cache." encrypted="false" />
+      <add name="EnableOfflineCaching" value="True" description="True to enable caching of user information for authentication in offline state, otherwise False." encrypted="false" />
+      <add name="PasswordRequirementsRegex" value="^.*(?=.{8,})(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).*$" description="Regular expression used to validate new passwords for database users." encrypted="false" />
+      <add name="PasswordRequirementsError" value="Invalid Password: Password must be at least 8 characters; must contain at least 1 number, 1 upper case letter, and 1 lower case letter" description="Error message to be displayed when new database user password fails regular expression test." encrypted="false" />
     </securityProvider>
-    <errorLogger>
-      <clear/>
-      <add name="   " value="False" description="True if an encountered exception is logged to the database; otherwise False." encrypted="false" scope="Application"/>
-    </errorLogger>
-	</categorizedSettings>
+  </categorizedSettings>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
-	<runtime>
-		<gcServer enabled="true"/>
-		<gcConcurrent enabled="true"/>
-	</runtime>
+  <runtime>
+    <gcServer enabled="true" />
+    <gcConcurrent enabled="true" />
+  </runtime>
 </configuration>

--- a/Source/Applications/openXDA/openXDA/AppDebug.config
+++ b/Source/Applications/openXDA/openXDA/AppDebug.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <section name="categorizedSettings" type="GSF.Configuration.CategorizedSettingsSection, GSF.Core" />
@@ -10,61 +10,60 @@
       <add name="DataProviderString" value="AssemblyName={System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089}; ConnectionType=System.Data.SqlClient.SqlConnection; AdapterType=System.Data.SqlClient.SqlDataAdapter" description="Configuration database ADO.NET data provider assembly type creation string used when ConfigurationType=Database" encrypted="false" />
       <!-- **************************************************************** -->
       <add name="NodeID" value="00000000-0000-0000-0000-000000000000" description="Unique Node ID" encrypted="false" />
-      <!-- *** DEBUG OPTIONS - CHANGE FOR PRODUCTION DEPLOYMENT *** -->
-      <add name="CompanyName" value="Grid Protection Alliance" description="The name of the company who owns this instance of the openMIC." encrypted="false" />
-      <add name="CompanyAcronym" value="GPA" description="The acronym representing the company who owns this instance of the openMIC." encrypted="false" />
+      <add name="CompanyName" value="Grid Protection Alliance" description="The name of the company who owns this instance of openXDA." encrypted="false" />
+      <add name="CompanyAcronym" value="GPA" description="The acronym representing the company who owns this instance of openXDA." encrypted="false" />
       <add name="DefaultCulture" value="en-US" description="Default culture to use for language, country/region and calendar formats." encrypted="false" />
       <add name="DateFormat" value="MM/dd/yyyy" description="The date format to use when rendering timestamps." encrypted="false" />
       <add name="TimeFormat" value="HH:mm.ss.fff" description="The time format to use when rendering timestamps." encrypted="false" />
       <add name="PQMarkUserName" value="username" description="User name for PQMarkWeb API access." encrypted="false" />
       <add name="PQMarkPassword" value="" description="Password for PQMarkWeb API access." encrypted="true" />
-      <add name="CertFile" value="openXDAhttps.cer" description="Cert File for https." encrypted="false" />
-      <add name="ValidPolicyErrors" value="RemoteCertificateNameMismatch, RemoteCertificateChainErrors" description="SSL Policy flags." encrypted="false" />
-      <add name="ValidChainFlags" value="UntrustedRoot" description="X509 Chain Flags." encrypted="false" />
+      <add name="CertFile" value="openXDAhttps.cer" description="Certificate for WebAPIHub used by PQMark/DataPusher." encrypted="false" />
+      <add name="ValidPolicyErrors" value="RemoteCertificateNameMismatch, RemoteCertificateChainErrors" description="Expected policy errors during remote server certificate validation for PQMark/DataPusher (self-signed: RemoteCertificateNameMismatch, RemoteCertificateChainErrors)." encrypted="false" />
+      <add name="ValidChainFlags" value="UntrustedRoot" description="Expected chain flags set during remote server certificate validation for PQMark/DataPusher (self-signed: UntrustedRoot)." encrypted="false" />
       <add name="SessionTimeout" value="20" description="The timeout, in minutes, for which inactive client sessions will be expired and removed from the cache." encrypted="false" />
       <add name="SessionMonitorInterval" value="60000" description="The interval, in milliseconds, over which the client session cache will be evaluated for expired sessions." encrypted="false" />
-      <add name="ConfigurationCachePath" value="ConfigurationCache\" description="Defines the path used to cache serialized configurations" encrypted="false"/>
+      <add name="ConfigurationCachePath" value="ConfigurationCache\" description="Defines the path used to cache serialized configurations" encrypted="false" />
 
       <!-- Necessary because of how razor engine for embedded resources works -->
       <!-- Note that changes to the value of this setting require the service to be restarted -->
-      <add name="EmbeddedTemplatePath" value="Eval(webHost.EmbeddedTemplatePath)" description="Embedded name space path for data context based razor field templates." encrypted="false"/>
+      <add name="EmbeddedTemplatePath" value="Eval(webHost.EmbeddedTemplatePath)" description="Embedded name space path for data context based razor field templates." encrypted="false" />
     </systemSettings>
     <webHost>
       <!-- Web host -->
-      <add name="WebHostURL" value="http://localhost:8989" description="The web hosting URL for remote system management." encrypted="false"/>
-      <add name="DefaultWebPage" value="index.cshtml" description="The default web page for the hosted web server." encrypted="false"/>
-      <add name="AllowedDomainList" value="*" description="Cross-domain access. Can have 1 domain or all domains. Use * for all domains and wildcards, e.g., *.consoto.com." encrypted="false"/>
+      <add name="WebHostURL" value="http://localhost:8989" description="The web hosting URL for remote system management." encrypted="false" />
+      <add name="DefaultWebPage" value="index.cshtml" description="The default web page for the hosted web server." encrypted="false" />
+      <add name="AllowedDomainList" value="*" description="Cross-domain access. Can have 1 domain or all domains. Use * for all domains and wildcards, e.g., *.consoto.com." encrypted="false" />
 
       <!-- Web server -->
-      <add name="WebRootPath" value="..\..\..\..\..\Source\Applications\openXDA\openXDA\wwwroot" description="The root path for the hosted web server files. Location will be relative to install folder if full path is not specified." encrypted="false"/>
-      <add name="ClientCacheEnabled" value="True" description="Determines if cache control is enabled for browser clients." encrypted="false"/>
-      <add name="MinifyStyleSheets" value="True" description="Determines if minification should be applied to rendered CSS files." encrypted="false"/>
-      <add name="UseMinifyInDebug" value="False" description="Determines if minification should be applied when running a Debug build." encrypted="false"/>
-      <add name="SessionToken" value="x-gsf-session" description="Defines the token used for identifying the session ID in cookie headers." encrypted="false"/>
-      <add name="AuthTestPage" value="/AuthTest" description="Defines the page name for the web server to test if a user is authenticated. Expects forward slash prefix." encrypted="false"/>
+      <add name="WebRootPath" value="..\..\..\..\..\Source\Applications\openXDA\openXDA\wwwroot" description="The root path for the hosted web server files. Location will be relative to install folder if full path is not specified." encrypted="false" />
+      <add name="ClientCacheEnabled" value="True" description="Determines if cache control is enabled for browser clients." encrypted="false" />
+      <add name="MinifyStyleSheets" value="True" description="Determines if minification should be applied to rendered CSS files." encrypted="false" />
+      <add name="UseMinifyInDebug" value="False" description="Determines if minification should be applied when running a Debug build." encrypted="false" />
+      <add name="SessionToken" value="x-gsf-session" description="Defines the token used for identifying the session ID in cookie headers." encrypted="false" />
+      <add name="AuthTestPage" value="/AuthTest" description="Defines the page name for the web server to test if a user is authenticated. Expects forward slash prefix." encrypted="false" />
 
       <!-- Razor engine -->
-      <add name="TemplatePath" value="Eval(webHost.WebRootPath)" description="Path for data context based razor field templates." encrypted="false"/>
-      <add name="EmbeddedTemplatePath" value="GSF.Web.Model.Views." description="Embedded name space path for data context based razor field templates." encrypted="false"/>
+      <add name="TemplatePath" value="Eval(webHost.WebRootPath)" description="Path for data context based razor field templates." encrypted="false" />
+      <add name="EmbeddedTemplatePath" value="GSF.Web.Model.Views." description="Embedded name space path for data context based razor field templates." encrypted="false" />
 
       <!-- Authentication -->
-      <add name="AuthenticationSchemes" value="Ntlm, Basic" description="Comma separated list of authentication schemes to use for clients accessing the hosted web server, e.g., Basic or NTLM." encrypted="false"/>
-      <add name="AuthFailureRedirectResourceExpression" value="^/$|^/.+\.cshtml$|^/.+\.vbhtml$|^/grafana(?!/api/).*$|^/api/auth/logon?.*$" description="Expression that will match paths for the resources on the web server that should redirect to the LoginPage when authentication fails." encrypted="false"/>
-      <add name="AnonymousResourceExpression" value="^/@|^/Scripts/|^/Content/|^/Images/|^/fonts/|^/favicon.ico$|^/api/auth/token$" description="Expression that will match paths for the resources on the web server that can be provided without checking credentials." encrypted="false"/>
-      <add name="AlternateSecurityProviderResourceExpression" value="^/$" description="Expression that will match paths for the resources on the web server that should use the alternate Security Provider." encrypted="false"/>
-      <add name="AuthenticationToken" value="x-gsf-auth" description="Defines the token used for identifying the authentication token in cookie headers." encrypted="false"/>
-      <!-- <add name="SessionToken" value="x-gsf-session" description="Defines the token used for identifying the session ID in cookie headers." encrypted="false"/> -->
-      <add name="RequestVerificationToken" value="X-GSF-Verify" description="Defines the token used for identifying the authentication token in cookie headers." encrypted="false"/>
-      <add name="LoginPage" value="/@GSF/Web/Security/Views/Login.cshtml" description="Defines the login page used for redirects on authentication failure. Expects forward slash prefix." encrypted="false"/>
-      <!-- <add name="AuthTestPage" value="/AuthTest" description="Defines the page name for the web server to test if a user is authenticated. Expects forward slash prefix." encrypted="false"/> -->
-      <add name="Realm" value="" description="Case-sensitive identifier that defines the protection space for the web based authentication and is used to indicate a scope of protection." encrypted="false"/>
+      <add name="AuthenticationSchemes" value="Ntlm, Basic" description="Comma separated list of authentication schemes to use for clients accessing the hosted web server, e.g., Basic or NTLM." encrypted="false" />
+      <add name="AuthFailureRedirectResourceExpression" value="^/$|^/.+\.cshtml$|^/.+\.vbhtml$|^/grafana(?!/api/).*$|^/api/auth/logon?.*$" description="Expression that will match paths for the resources on the web server that should redirect to the LoginPage when authentication fails." encrypted="false" />
+      <add name="AnonymousResourceExpression" value="^/@|^/Scripts/|^/Content/|^/Images/|^/fonts/|^/favicon.ico$|^/api/auth/token$" description="Expression that will match paths for the resources on the web server that can be provided without checking credentials." encrypted="false" />
+      <add name="AlternateSecurityProviderResourceExpression" value="(?!)" description="Expression that will match paths for the resources on the web server that should use the alternate Security Provider." encrypted="false" />
+      <add name="AuthenticationToken" value="x-gsf-auth" description="Defines the token used for identifying the authentication token in cookie headers." encrypted="false" />
+      <!-- <add name="SessionToken" value="x-gsf-session" description="Defines the token used for identifying the session ID in cookie headers." encrypted="false" /> -->
+      <add name="RequestVerificationToken" value="X-GSF-Verify" description="Defines the token used for identifying the authentication token in cookie headers." encrypted="false" />
+      <add name="LoginPage" value="/@GSF/Web/Security/Views/Login.cshtml" description="Defines the login page used for redirects on authentication failure. Expects forward slash prefix." encrypted="false" />
+      <!-- <add name="AuthTestPage" value="/AuthTest" description="Defines the page name for the web server to test if a user is authenticated. Expects forward slash prefix." encrypted="false" /> -->
+      <add name="Realm" value="" description="Case-sensitive identifier that defines the protection space for the web based authentication and is used to indicate a scope of protection." encrypted="false" />
 
       <!-- App model -->
-      <add name="CompanyName" value="Eval(systemSettings.CompanyName)" description="The name of the company who owns this instance of openXDA." encrypted="false"/>
-      <add name="CompanyAcronym" value="Eval(systemSettings.CompanyAcronym)" description="The acronym representing the company who owns this instance of openXDA." encrypted="false"/>
-      <add name="DateFormat" value="Eval(systemSettings.DateFormat)" description="The date format to use when rendering timestamps." encrypted="false"/>
-      <add name="TimeFormat" value="Eval(systemSettings.TimeFormat)" description="The time format to use when rendering timestamps." encrypted="false"/>
-      <add name="BootstrapTheme" value="Content/bootstrap-theme.min.css" description="Path to Bootstrap CSS to use for rendering styles." encrypted="false"/>
+      <add name="CompanyName" value="Eval(systemSettings.CompanyName)" description="The name of the company who owns this instance of openXDA." encrypted="false" />
+      <add name="CompanyAcronym" value="Eval(systemSettings.CompanyAcronym)" description="The acronym representing the company who owns this instance of openXDA." encrypted="false" />
+      <add name="DateFormat" value="Eval(systemSettings.DateFormat)" description="The date format to use when rendering timestamps." encrypted="false" />
+      <add name="TimeFormat" value="Eval(systemSettings.TimeFormat)" description="The time format to use when rendering timestamps." encrypted="false" />
+      <add name="BootstrapTheme" value="Content/bootstrap-theme.min.css" description="Path to Bootstrap CSS to use for rendering styles." encrypted="false" />
     </webHost>
     <securityProvider>
       <add name="ApplicationName" value="openXDA" description="Name of the application being secured as defined in the backend security datastore." encrypted="false" />

--- a/Source/Applications/openXDA/openXDA/AppDebug.config
+++ b/Source/Applications/openXDA/openXDA/AppDebug.config
@@ -81,6 +81,8 @@
       <add name="EnableOfflineCaching" value="True" description="True to enable caching of user information for authentication in offline state, otherwise False." encrypted="false" />
       <add name="PasswordRequirementsRegex" value="^.*(?=.{8,})(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).*$" description="Regular expression used to validate new passwords for database users." encrypted="false" />
       <add name="PasswordRequirementsError" value="Invalid Password: Password must be at least 8 characters; must contain at least 1 number, 1 upper case letter, and 1 lower case letter" description="Error message to be displayed when new database user password fails regular expression test." encrypted="false" />
+      <add name="AzureADConfigSource" value="appsettings.json" description="Azure AD configuration source. Either 'appsettings.json' file path or settings category to use." encrypted="false" />
+      <add name="AzureADSecret" value="env(User:openXDASecretKey)" description="Defines the Azure AD secret value to be used for user info and group lookups, post authentication." encrypted="false" />
     </securityProvider>
     <alternateSecurityProvider>
       <add name="ApplicationName" value="GPAGeneral" description="Name of the application being secured as defined in the backend security datastore." encrypted="false" />

--- a/Source/Libraries/openXDA.DataPusher/WebAPIHub.cs
+++ b/Source/Libraries/openXDA.DataPusher/WebAPIHub.cs
@@ -285,9 +285,9 @@ namespace openXDA.DataPusher
             SimpleCertificateChecker simpleCertificateChecker = new SimpleCertificateChecker();
 
             CategorizedSettingsElementCollection systemSettings = ConfigurationFile.Current.Settings["systemSettings"];
-            systemSettings.Add("CertFile", "", "This is a certfile.");
-            systemSettings.Add("ValidPolicyErrors", "None", "Password for PQMarkWeb API access.");
-            systemSettings.Add("ValidChainFlags", "NoError", "Password for PQMarkWeb API access.");
+            systemSettings.Add("CertFile", "", "Certificate for WebAPIHub used by PQMark/DataPusher.");
+            systemSettings.Add("ValidPolicyErrors", "None", "Expected policy errors during remote server certificate validation for PQMark/DataPusher (self-signed: RemoteCertificateNameMismatch, RemoteCertificateChainErrors).");
+            systemSettings.Add("ValidChainFlags", "NoError", "Expected chain flags set during remote server certificate validation for PQMark/DataPusher (self-signed: UntrustedRoot).");
 
             try
             {


### PR DESCRIPTION
* Use spaces for indentation instead of tabs
* Update useless/incorrect descriptions for PQMark/DataPusher config file settings
* Consistently add a space between the last attribute and the closing tag for single-line elements
* Disable the alternate security provider in `AppDebug.config` because it's annoying
* Remove the `errorLog` section from `App.config`
* Remove the byte-order mark from `AppDebug.config`
* Add the new settings for Azure AD authentication