### PR TITLE
Optimize usage of lazy context for directly referenced models

### DIFF
--- a/Source/Libraries/openXDA.Model/Channels/Channel.cs
+++ b/Source/Libraries/openXDA.Model/Channels/Channel.cs
@@ -207,12 +207,15 @@ namespace openXDA.Model
         {
             get
             {
-                return m_measurementType ?? (m_measurementType = QueryMeasurementType());
+                if (m_measurementType is null)
+                    m_measurementType = LazyContext.GetMeasurementType(MeasurementTypeID);
+
+                if (m_measurementType is null)
+                    m_measurementType = QueryMeasurementType();
+
+                return m_measurementType;
             }
-            set
-            {
-                m_measurementType = value;
-            }
+            set => m_measurementType = value;
         }
 
         [JsonIgnore]
@@ -221,12 +224,15 @@ namespace openXDA.Model
         {
             get
             {
-                return m_measurementCharacteristic ?? (m_measurementCharacteristic = QueryMeasurementCharacteristic());
+                if (m_measurementCharacteristic is null)
+                    m_measurementCharacteristic = LazyContext.GetMeasurementCharacteristic(MeasurementCharacteristicID);
+
+                if (m_measurementCharacteristic is null)
+                    m_measurementCharacteristic = QueryMeasurementCharacteristic();
+
+                return m_measurementCharacteristic;
             }
-            set
-            {
-                m_measurementCharacteristic = value;
-            }
+            set => m_measurementCharacteristic = value;
         }
 
         [JsonIgnore]
@@ -235,12 +241,15 @@ namespace openXDA.Model
         {
             get
             {
-                return m_phase ?? (m_phase = QueryPhase());
+                if (m_phase is null)
+                    m_phase = LazyContext.GetPhase(PhaseID);
+
+                if (m_phase is null)
+                    m_phase = QueryPhase();
+
+                return m_phase;
             }
-            set
-            {
-                m_phase = value;
-            }
+            set => m_phase = value;
         }
 
         [JsonIgnore]
@@ -249,12 +258,15 @@ namespace openXDA.Model
         {
             get
             {
-                return m_meter ?? (m_meter = QueryMeter());
+                if (m_meter is null)
+                    m_meter = LazyContext.GetMeter(MeterID);
+
+                if (m_meter is null)
+                    m_meter = QueryMeter();
+
+                return m_meter;
             }
-            set
-            {
-                m_meter = value;
-            }
+            set => m_meter = value;
         }
 
         [JsonIgnore]
@@ -263,40 +275,31 @@ namespace openXDA.Model
         {
             get
             {
-                return m_asset ?? (m_asset = QueryAsset());
+                if (m_asset is null)
+                    m_asset = LazyContext.GetAsset(AssetID);
+
+                if (m_asset is null)
+                    m_asset = QueryAsset();
+
+                return m_asset;
             }
-            set
-            {
-                m_asset = value;
-            }
+            set => m_asset = value;
         }
 
         [JsonIgnore]
         [NonRecordField]
         public List<Series> Series
         {
-            get
-            {
-                return m_series ?? (m_series = QuerySeries());
-            }
-            set
-            {
-                m_series = value;
-            }
+            get => m_series ?? (m_series = QuerySeries());
+            set => m_series = value;
         }
 
         [JsonIgnore]
         [NonRecordField]
         public Func<AdoDataConnection> ConnectionFactory
         {
-            get
-            {
-                return LazyContext.ConnectionFactory;
-            }
-            set
-            {
-                LazyContext.ConnectionFactory = value;
-            }
+            get => LazyContext.ConnectionFactory;
+            set => LazyContext.ConnectionFactory = value;
         }
 
         [JsonIgnore]

--- a/Source/Libraries/openXDA.Model/Channels/Series.cs
+++ b/Source/Libraries/openXDA.Model/Channels/Series.cs
@@ -153,12 +153,15 @@ namespace openXDA.Model
         {
             get
             {
-                return m_seriesType ?? (m_seriesType = QuerySeriesType());
+                if (m_seriesType is null)
+                    m_seriesType = LazyContext.GetSeriesType(SeriesTypeID);
+
+                if (m_seriesType is null)
+                    m_seriesType = QuerySeriesType();
+
+                return m_seriesType;
             }
-            set
-            {
-                m_seriesType = value;
-            }
+            set => m_seriesType = value;
         }
 
         [JsonIgnore]
@@ -167,26 +170,23 @@ namespace openXDA.Model
         {
             get
             {
-                return m_channel ?? (m_channel = QueryChannel());
+                if (m_channel is null)
+                    m_channel = LazyContext.GetChannel(ChannelID);
+
+                if (m_channel is null)
+                    m_channel = QueryChannel();
+
+                return m_channel;
             }
-            set
-            {
-                m_channel = value;
-            }
+            set => m_channel = value;
         }
 
         [JsonIgnore]
         [NonRecordField]
         public Func<AdoDataConnection> ConnectionFactory
         {
-            get
-            {
-                return LazyContext.ConnectionFactory;
-            }
-            set
-            {
-                LazyContext.ConnectionFactory = value;
-            }
+            get => LazyContext.ConnectionFactory;
+            set => LazyContext.ConnectionFactory = value;
         }
 
         [JsonIgnore]

--- a/Source/Libraries/openXDA.Model/LazyContext.cs
+++ b/Source/Libraries/openXDA.Model/LazyContext.cs
@@ -86,6 +86,11 @@ namespace openXDA.Model
 
         #region [ Methods ]
 
+        public Location GetLocation(int locationID) =>
+            m_locations.TryGetValue(locationID, out Location location)
+                ? location
+                : null;
+
         public Location GetLocation(Location location)
         {
             Location cachedLocation;
@@ -102,6 +107,11 @@ namespace openXDA.Model
             m_locations.Add(location.ID, location);
             return location;
         }
+
+        public Meter GetMeter(int meterID) =>
+            m_meters.TryGetValue(meterID, out Meter meter)
+                ? meter
+                : null;
 
         public Meter GetMeter(Meter meter)
         {
@@ -120,6 +130,11 @@ namespace openXDA.Model
             return meter;
         }
 
+        public Asset GetAsset(int assetID) =>
+            m_assets.TryGetValue(assetID, out Asset asset)
+                ? asset
+                : null;
+
         public Asset GetAsset(Asset asset)
         {
             Asset cachedAsset;
@@ -136,6 +151,11 @@ namespace openXDA.Model
             m_assets.Add(asset.ID, asset);
             return asset;
         }
+
+        public AssetLocation GetAssetLocation(int assetLocationID) =>
+            m_assetLocations.TryGetValue(assetLocationID, out AssetLocation assetLocation)
+                ? assetLocation
+                : null;
 
         public AssetLocation GetAssetLocation(AssetLocation assetLocation)
         {
@@ -154,6 +174,11 @@ namespace openXDA.Model
             return assetLocation;
         }
 
+        public SourceImpedance GetSourceImpedance(int sourceImpedanceID) =>
+            m_sourceImpedances.TryGetValue(sourceImpedanceID, out SourceImpedance sourceImpedance)
+                ? sourceImpedance
+                : null;
+
         public SourceImpedance GetSourceImpedance(SourceImpedance sourceImpedance)
         {
             SourceImpedance cachedSourceImpedance;
@@ -170,6 +195,11 @@ namespace openXDA.Model
             m_sourceImpedances.Add(sourceImpedance.ID, sourceImpedance);
             return sourceImpedance;
         }
+
+        public MeterAsset GetMeterAsset(int meterAssetID) =>
+            m_meterAssets.TryGetValue(meterAssetID, out MeterAsset meterAsset)
+                ? meterAsset
+                : null;
 
         public MeterAsset GetMeterAsset(MeterAsset meterAsset)
         {
@@ -188,6 +218,11 @@ namespace openXDA.Model
             return meterAsset;
         }
 
+        public Channel GetChannel(int channelID) =>
+            m_channels.TryGetValue(channelID, out Channel channel)
+                ? channel
+                : null;
+
         public Channel GetChannel(Channel channel)
         {
             Channel cachedChannelLine;
@@ -204,6 +239,11 @@ namespace openXDA.Model
             m_channels.Add(channel.ID, channel);
             return channel;
         }
+
+        public Series GetSeries(int seriesID) =>
+            m_series.TryGetValue(seriesID, out Series series)
+                ? series
+                : null;
 
         public Series GetSeries(Series series)
         {
@@ -222,6 +262,11 @@ namespace openXDA.Model
             return series;
         }
 
+        public MeasurementType GetMeasurementType(int measurementTypeID) =>
+            m_measurementTypes.TryGetValue(measurementTypeID, out MeasurementType measurementType)
+                ? measurementType
+                : null;
+
         public MeasurementType GetMeasurementType(MeasurementType measurementType)
         {
             MeasurementType cachedMeasurementTypeLine;
@@ -238,6 +283,11 @@ namespace openXDA.Model
             m_measurementTypes.Add(measurementType.ID, measurementType);
             return measurementType;
         }
+
+        public MeasurementCharacteristic GetMeasurementCharacteristic(int measurementCharacteristicID) =>
+            m_measurementCharacteristics.TryGetValue(measurementCharacteristicID, out MeasurementCharacteristic measurementCharacteristic)
+                ? measurementCharacteristic
+                : null;
 
         public MeasurementCharacteristic GetMeasurementCharacteristic(MeasurementCharacteristic measurementCharacteristic)
         {
@@ -256,6 +306,11 @@ namespace openXDA.Model
             return measurementCharacteristic;
         }
 
+        public Phase GetPhase(int phaseID) =>
+            m_phases.TryGetValue(phaseID, out Phase phase)
+                ? phase
+                : null;
+
         public Phase GetPhase(Phase phase)
         {
             Phase cachedPhaseLine;
@@ -272,6 +327,11 @@ namespace openXDA.Model
             m_phases.Add(phase.ID, phase);
             return phase;
         }
+
+        public SeriesType GetSeriesType(int seriesTypeID) =>
+            m_seriesTypes.TryGetValue(seriesTypeID, out SeriesType seriesType)
+                ? seriesType
+                : null;
 
         public SeriesType GetSeriesType(SeriesType seriesType)
         {
@@ -290,6 +350,11 @@ namespace openXDA.Model
             return seriesType;
         }
 
+        public AssetConnection GetAssetConnection(int connectionID) =>
+            m_assetConnections.TryGetValue(connectionID, out AssetConnection connection)
+                ? connection
+                : null;
+
         public AssetConnection GetAssetConnection(AssetConnection connection)
         {
             AssetConnection cachedConnection;
@@ -306,6 +371,11 @@ namespace openXDA.Model
             m_assetConnections.Add(connection.ID, connection);
             return connection;
         }
+
+        public LineSegmentConnections GetLineSegmentConnection(int connectionID) =>
+            m_segmentConnections.TryGetValue(connectionID, out LineSegmentConnections connection)
+                ? connection
+                : null;
 
         public LineSegmentConnections GetLineSegmentConnection(LineSegmentConnections connection)
         {
@@ -324,6 +394,11 @@ namespace openXDA.Model
             return connection;
         }
 
+        public Line GetLine(int lineID) =>
+            m_lines.TryGetValue(lineID, out Line line)
+                ? line
+                : null;
+
         public Line GetLine(Line line)
         {
             Line cachedLine;
@@ -340,6 +415,11 @@ namespace openXDA.Model
             m_lines.Add(line.ID, line);
             return line;
         }
+
+        public CapBankRelay GetRelay(int relayID) =>
+            m_relays.TryGetValue(relayID, out CapBankRelay relay)
+                ? relay
+                : null;
 
         public CapBankRelay GetRelay(CapBankRelay relay)
         {
@@ -358,24 +438,27 @@ namespace openXDA.Model
             return relay;
         }
 
+        public LineSegment GetLineSegment(int lineSegmentID) =>
+            m_lineSegments.TryGetValue(lineSegmentID, out LineSegment lineSegment)
+                ? lineSegment
+                : null;
 
-        public LineSegment GetLineSegment(LineSegment line)
+        public LineSegment GetLineSegment(LineSegment lineSegment)
         {
             LineSegment cachedLine;
 
-            if ((object)line == null)
+            if ((object)lineSegment == null)
                 return null;
 
-            if (line.ID == 0)
-                return line;
+            if (lineSegment.ID == 0)
+                return lineSegment;
 
-            if (m_lineSegments.TryGetValue(line.ID, out cachedLine))
+            if (m_lineSegments.TryGetValue(lineSegment.ID, out cachedLine))
                 return cachedLine;
 
-            m_lineSegments.Add(line.ID, line);
-            return line;
+            m_lineSegments.Add(lineSegment.ID, lineSegment);
+            return lineSegment;
         }
-
 
         #endregion
     }

--- a/Source/Libraries/openXDA.Model/Links/AssetConnection.cs
+++ b/Source/Libraries/openXDA.Model/Links/AssetConnection.cs
@@ -61,12 +61,15 @@ namespace openXDA.Model
         {
             get
             {
-                return m_parent ?? (m_parent = QueryParent());
+                if (m_parent is null)
+                    m_parent = LazyContext.GetAsset(ParentID);
+
+                if (m_parent is null)
+                    m_parent = QueryParent();
+
+                return m_parent;
             }
-            set
-            {
-                m_parent = value;
-            }
+            set => m_parent = value;
         }
 
         [JsonIgnore]
@@ -75,26 +78,23 @@ namespace openXDA.Model
         {
             get
             {
-                return m_child ?? (m_child = QueryChild());
+                if (m_child is null)
+                    m_child = LazyContext.GetAsset(ChildID);
+
+                if (m_child is null)
+                    m_child = QueryChild();
+
+                return m_child;
             }
-            set
-            {
-                m_child = value;
-            }
+            set => m_child = value;
         }
 
         [JsonIgnore]
         [NonRecordField]
         public Func<AdoDataConnection> ConnectionFactory
         {
-            get
-            {
-                return LazyContext.ConnectionFactory;
-            }
-            set
-            {
-                LazyContext.ConnectionFactory = value;
-            }
+            get => LazyContext.ConnectionFactory;
+            set => LazyContext.ConnectionFactory = value;
         }
 
         [JsonIgnore]

--- a/Source/Libraries/openXDA.Model/Links/LineSegmentConnections.cs
+++ b/Source/Libraries/openXDA.Model/Links/LineSegmentConnections.cs
@@ -55,12 +55,15 @@ namespace openXDA.Model
         {
             get
             {
-                return m_parent ?? (m_parent = QueryParent());
+                if (m_parent is null)
+                    m_parent = LazyContext.GetLineSegment(ParentSegment);
+
+                if (m_parent is null)
+                    m_parent = QueryParent();
+
+                return m_parent;
             }
-            set
-            {
-                m_parent = value;
-            }
+            set => m_parent = value;
         }
 
         [JsonIgnore]
@@ -69,26 +72,23 @@ namespace openXDA.Model
         {
             get
             {
-                return m_child ?? (m_child = QueryChild());
+                if (m_child is null)
+                    m_child = LazyContext.GetLineSegment(ChildSegment);
+
+                if (m_child is null)
+                    m_child = QueryChild();
+
+                return m_child;
             }
-            set
-            {
-                m_child = value;
-            }
+            set => m_child = value;
         }
 
         [JsonIgnore]
         [NonRecordField]
         public Func<AdoDataConnection> ConnectionFactory
         {
-            get
-            {
-                return LazyContext.ConnectionFactory;
-            }
-            set
-            {
-                LazyContext.ConnectionFactory = value;
-            }
+            get => LazyContext.ConnectionFactory;
+            set => LazyContext.ConnectionFactory = value;
         }
 
         [JsonIgnore]

--- a/Source/Libraries/openXDA.Model/Links/MeterLine.cs
+++ b/Source/Libraries/openXDA.Model/Links/MeterLine.cs
@@ -57,12 +57,15 @@ namespace openXDA.Model
         {
             get
             {
-                return m_meter ?? (m_meter = QueryMeter());
+                if (m_meter is null)
+                    m_meter = LazyContext.GetMeter(MeterID);
+
+                if (m_meter is null)
+                    m_meter = QueryMeter();
+
+                return m_meter;
             }
-            set
-            {
-                m_meter = value;
-            }
+            set => m_meter = value;
         }
 
         [JsonIgnore]
@@ -71,26 +74,23 @@ namespace openXDA.Model
         {
             get
             {
-                return m_asset ?? (m_asset = QueryAsset());
+                if (m_asset is null)
+                    m_asset = LazyContext.GetAsset(AssetID);
+
+                if (m_asset is null)
+                    m_asset = QueryAsset();
+
+                return m_asset;
             }
-            set
-            {
-                m_asset = value;
-            }
+            set => m_asset = value;
         }
 
         [JsonIgnore]
         [NonRecordField]
         public Func<AdoDataConnection> ConnectionFactory
         {
-            get
-            {
-                return LazyContext.ConnectionFactory;
-            }
-            set
-            {
-                LazyContext.ConnectionFactory = value;
-            }
+            get => LazyContext.ConnectionFactory;
+            set => LazyContext.ConnectionFactory = value;
         }
 
         [JsonIgnore]

--- a/Source/Libraries/openXDA.Model/Links/MeterLocationLine.cs
+++ b/Source/Libraries/openXDA.Model/Links/MeterLocationLine.cs
@@ -35,7 +35,7 @@ namespace openXDA.Model
         #region [ Members ]
 
         // Fields
-        private Location m_Location;
+        private Location m_location;
         private Asset m_asset;
         private SourceImpedance m_sourceImpedance;
 
@@ -56,12 +56,15 @@ namespace openXDA.Model
         {
             get
             {
-                return m_Location ?? (m_Location = QueryLocation());
+                if (m_location is null)
+                    m_location = LazyContext.GetLocation(LocationID);
+
+                if (m_location is null)
+                    m_location = QueryLocation();
+
+                return m_location;
             }
-            set
-            {
-                m_Location = value;
-            }
+            set => m_location = value;
         }
 
         [JsonIgnore]
@@ -70,40 +73,31 @@ namespace openXDA.Model
         {
             get
             {
-                return m_asset ?? (m_asset ?? QueryAsset());
+                if (m_asset is null)
+                    m_asset = LazyContext.GetAsset(AssetID);
+
+                if (m_asset is null)
+                    m_asset = QueryAsset();
+
+                return m_asset;
             }
-            set
-            {
-                m_asset = value;
-            }
+            set => m_asset = value;
         }
 
         [JsonIgnore]
         [NonRecordField]
         public SourceImpedance SourceImpedance
         {
-            get
-            {
-                return m_sourceImpedance ?? (m_sourceImpedance ?? QuerySourceImpedance());
-            }
-            set
-            {
-                m_sourceImpedance = value;
-            }
+            get => m_sourceImpedance ?? (m_sourceImpedance ?? QuerySourceImpedance());
+            set => m_sourceImpedance = value;
         }
 
         [JsonIgnore]
         [NonRecordField]
         public Func<AdoDataConnection> ConnectionFactory
         {
-            get
-            {
-                return LazyContext.ConnectionFactory;
-            }
-            set
-            {
-                LazyContext.ConnectionFactory = value;
-            }
+            get => LazyContext.ConnectionFactory;
+            set => LazyContext.ConnectionFactory = value;
         }
 
         [JsonIgnore]

--- a/Source/Libraries/openXDA.Model/Meters/Meter.cs
+++ b/Source/Libraries/openXDA.Model/Meters/Meter.cs
@@ -97,40 +97,31 @@ namespace openXDA.Model
         {
             get
             {
-                return m_location ?? (m_location = QueryLocation());
+                if (m_location is null)
+                    m_location = LazyContext.GetLocation(LocationID);
+
+                if (m_location is null)
+                    m_location = QueryLocation();
+
+                return m_location;
             }
-            set
-            {
-                m_location = value;
-            }
+            set => m_location = value;
         }
 
         [JsonIgnore]
         [NonRecordField]
         public List<MeterAsset> MeterAssets
         {
-            get
-            {
-                return m_meterAssets ?? (m_meterAssets = QueryMeterAssets());
-            }
-            set
-            {
-                m_meterAssets = value;
-            }
+            get => m_meterAssets ?? (m_meterAssets = QueryMeterAssets());
+            set => m_meterAssets = value;
         }
 
         [JsonIgnore]
         [NonRecordField]
         public List<Channel> Channels
         {
-            get
-            {
-                return m_channels ?? (m_channels = QueryChannels());
-            }
-            set
-            {
-                m_channels = value;
-            }
+            get => m_channels ?? (m_channels = QueryChannels());
+            set => m_channels = value;
         }
 
         public List<Series> Series
@@ -171,14 +162,8 @@ namespace openXDA.Model
         [NonRecordField]
         public Func<AdoDataConnection> ConnectionFactory
         {
-            get
-            {
-                return LazyContext.ConnectionFactory;
-            }
-            set
-            {
-                LazyContext.ConnectionFactory = value;
-            }
+            get => LazyContext.ConnectionFactory;
+            set => LazyContext.ConnectionFactory = value;
         }
 
         [JsonIgnore]

--- a/Source/Libraries/openXDA.Model/TransmissionElements/LineSegment.cs
+++ b/Source/Libraries/openXDA.Model/TransmissionElements/LineSegment.cs
@@ -65,28 +65,16 @@ namespace openXDA.Model
         [NonRecordField]
         public Line Line
         {
-            get
-            {
-                return m_line ?? (m_line = QueryLine());
-            }
-            set
-            {
-                m_line = value;
-            }
+            get => m_line ?? (m_line = QueryLine());
+            set => m_line = value;
         }
 
         [JsonIgnore]
         [NonRecordField]
         public List<LineSegmentConnections> connectedSegments
         {
-            get
-            {
-                return m_connectedSegements ?? (m_connectedSegements = QueryConnectedSegements());
-            }
-            set
-            {
-                m_connectedSegements = value;
-            }
+            get => m_connectedSegements ?? (m_connectedSegements = QueryConnectedSegements());
+            set => m_connectedSegements = value;
         }
 
         #endregion
@@ -111,11 +99,10 @@ namespace openXDA.Model
             return DetailedLineSegment(asset,asset.ConnectionFactory.Invoke());
         }
 
-        public Line GetLine( AdoDataConnection connection)
+        public Line GetLine(AdoDataConnection connection)
         {
             if ((object)connection == null)
                 return null;
-
 
             int id = -1;
 
@@ -145,27 +132,22 @@ namespace openXDA.Model
 
             using (AdoDataConnection connection = ConnectionFactory?.Invoke())
             {
-                line = LazyContext.GetLine(GetLine(connection));
+                line = GetLine(connection);
             }
 
             if ((object)line != null)
-            {
                 line.LazyContext = LazyContext;
-                
-            }
 
-            return line;
+            return LazyContext.GetLine(line);
         }
 
         public IEnumerable<LineSegmentConnections> GetConnectedSegments(AdoDataConnection connection)
         {
-
             if ((object)connection == null)
                 return null;
 
             TableOperations<LineSegmentConnections> connectionTable = new TableOperations<LineSegmentConnections>(connection);
             return connectionTable.QueryRecordsWhere("ParentSegment = {0} OR ChildSegment = {1}", ID, ID);
-
         }
 
         private List<LineSegmentConnections> QueryConnectedSegements()

--- a/Source/Libraries/openXDA.Model/TransmissionElements/SourceImpedance.cs
+++ b/Source/Libraries/openXDA.Model/TransmissionElements/SourceImpedance.cs
@@ -55,26 +55,23 @@ namespace openXDA.Model
         {
             get
             {
-                return m_assetLocation ?? (m_assetLocation = QueryAssetLocation());
+                if (m_assetLocation is null)
+                    m_assetLocation = LazyContext.GetAssetLocation(AssetLocationID);
+
+                if (m_assetLocation is null)
+                    m_assetLocation = QueryAssetLocation();
+
+                return m_assetLocation;
             }
-            set
-            {
-                m_assetLocation = value;
-            }
+            set => m_assetLocation = value;
         }
 
         [JsonIgnore]
         [NonRecordField]
         public Func<AdoDataConnection> ConnectionFactory
         {
-            get
-            {
-                return LazyContext.ConnectionFactory;
-            }
-            set
-            {
-                LazyContext.ConnectionFactory = value;
-            }
+            get => LazyContext.ConnectionFactory;
+            set => LazyContext.ConnectionFactory = value;
         }
 
         [JsonIgnore]


### PR DESCRIPTION
Updates the pattern for lazy loading models that are directly referenced by ID from other models. Essentially, this skips the database query if the model can already be found in the LazyContext's lookup tables.

This generally doesn't have much of an impact except in cases where a meter has a large number of channels. A sneaky example of this would be the following loop which triggers 600 queries if the meter has 200 channels.

https://github.com/GridProtectionAlliance/openXDA/blob/7d80a9db7775e99c7b07ba4a97aa90ac98c106c5/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs#L764-L768

It's because the `ChannelKey` constructor accesses the `MeasurementType`, `MeasurementCharacteristic`, and `Phase` properties, each of which triggers its own database query. In this case, there is a lot of overlap between different channels that enables us to bypass a lot of those queries.