### PR TITLE
Skip update query if channel enabled state doesn't change

### DIFF
--- a/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
@@ -763,7 +763,12 @@ namespace FaultData.DataOperations
 
                 foreach (Channel channel in meterDataSet.Meter.Channels)
                 {
-                    channel.Enabled = parsedChannelLookup.Contains(new ChannelKey(channel));
+                    bool enabled = parsedChannelLookup.Contains(new ChannelKey(channel));
+
+                    if (enabled == channel.Enabled)
+                        continue;
+
+                    channel.Enabled = enabled;
                     channelTable.UpdateRecord(channel);
                 }
             }


### PR DESCRIPTION
Simple optimization to avoid performing UPDATE queries that don't actually change the `Enabled` state of the channel.