### PR TITLE
Integration of nightly builds with Jenkins

### DIFF
--- a/Build/Scripts/UpdateDependencies.bat
+++ b/Build/Scripts/UpdateDependencies.bat
@@ -88,9 +88,16 @@ IF NOT "%donotpush%" == "" GOTO Finish
 :PushChanges
 ECHO.
 ECHO Pushing changes to remote repository...
-"%git%" push
+FOR /F "tokens=* USEBACKQ" %%F IN (`"%git%" describe --tags --abbrev^=0`) DO SET version=%%F
+SET remotebranch=master
+IF "%pushtoversionbranch%" == "true" SET remotebranch=ud-%version%
+"%git%" push origin HEAD:%remotebranch%
+
+:AfterPushChanges
 CD /D %pwd%
+IF EXIST "%afterpushscript%" CALL "%afterpushscript%" openXDA %remotebranch%
 
 :Finish
+CD /D %pwd%
 ECHO.
 ECHO Update complete

--- a/Build/Scripts/openXDA.buildproj
+++ b/Build/Scripts/openXDA.buildproj
@@ -163,4 +163,8 @@
       <ArchiveDestinations Include="$(BuildDeployFolder)"/>
     </ItemGroup>
   </Target>
+
+  <Target Name="AfterPushToServer" Condition="'$(DoNotPush)' == 'false' And '$(SkipVersioning)' != 'true'">
+    <Exec Command="%22$(AfterPushScript)%22 $(ProjectName) $(BuildTag)" Condition="'$(PushToVersionBranch)' == 'true' And Exists('$(AfterPushScript)')" />
+  </Target>
 </Project>


### PR DESCRIPTION
`UpdateDependencies.bat`
* Get the repo version from Git tags with `git describe --tags --abbrev=0`
* Set `remotebranch` to either `master` or `ud-%version%` depending on the `PushToVersionBranch` option
* After pushing, invoke the `AfterPushScript` to create the pull request

`openXDA.buildproj`
* Override the `AfterPushToServer` target, invoking the `AfterPushScript` to create the pull request