### PR TITLE
Fixed Voltage count issue for Fault Identification

### DIFF
--- a/Source/Libraries/FaultData/DataAnalysis/VIDataGroup.cs
+++ b/Source/Libraries/FaultData/DataAnalysis/VIDataGroup.cs
@@ -146,7 +146,8 @@ namespace FaultData.DataAnalysis
                         m_irIndex = item.Index;
                 }
 
-                m_vIndices.Add(set);
+                if (set.DefinedLineVoltages + set.DefinedNeutralVoltages > 0)
+                    m_vIndices.Add(set);
             }
 
             if (m_vIndices.Count() == 0)
@@ -340,7 +341,7 @@ namespace FaultData.DataAnalysis
                 // If all line voltages are already present or there are not
                 // at least 2 lines we will not perform line to line calculations
                 if (m_vIndices[i].DefinedLineVoltages == 3 || m_vIndices[i].DefinedNeutralVoltages < 2)
-                    return;
+                    continue;
 
                 // Get the meter associated with the channels in this data group
                 DataSeries VA = null;


### PR DESCRIPTION
This is 2 related issues that caused the Fault Data Resource to not recognize a Fault because it doesn't recognize that a `VIDataset` has all Voltages when a Bus is connected to a Line.

(1) If the first `VIndex` has all -1 (because the Asset itself has no Voltages) it will incorrectly use that to determine no Voltages available, even if a full set of Voltages is on the next `VIndex` (the Bus)

(2) When computing LL Voltages it would also fail out at the first `Vindex` rather then moving on to the next `VIndex` since it is unable to calculate LL if no LN are available. 