### PR TITLE
Write KML files to the configured directory, not its parent

### DIFF
--- a/Source/Libraries/FaultData/DataWriters/Emails/EmailService.cs
+++ b/Source/Libraries/FaultData/DataWriters/Emails/EmailService.cs
@@ -689,21 +689,20 @@ namespace FaultData.DataWriters.Emails
             }
         }
 
-        private void WriteEmailToFile(string path, MailMessage mail)
+        private void WriteEmailToFile(string datafolder, MailMessage mail)
         {
-            if (string.IsNullOrEmpty(path))
+            if (string.IsNullOrEmpty(datafolder))
                 return;
 
-            string datafolder = Path.GetDirectoryName(path);
             Directory.CreateDirectory(datafolder);
             string dstFile = Path.Combine(datafolder, mail.Subject);
 
             if (File.Exists(dstFile))
                 File.Delete(dstFile);
-            using (StreamWriter fileWriter = new StreamWriter(File.OpenWrite(dstFile)))
+            using (StreamWriter fileWriter = File.CreateText(dstFile))
                 fileWriter.Write(mail.Body);
-                
         }
+
         public void SendAdminEmail(string subject, string message, List<string> replyToRecipients)
         {
             Settings settings = new Settings(Configure);


### PR DESCRIPTION
Also switched from `File.OpenWrite()` to `File.CreateText()` so that the contents for existing files will be overwritten. Otherwise, we may end up with leftover data when overwriting existing files.