### PR TITLE
ChannelGroupModelPerms

### DIFF
--- a/Source/Libraries/openXDA.Model/Channels/ChannelGroupType.cs
+++ b/Source/Libraries/openXDA.Model/Channels/ChannelGroupType.cs
@@ -64,11 +64,6 @@ namespace openXDA.Model
 	        MeasurementType ON ChannelGroupType.MeasurementTypeID = MeasurementType.ID JOIN
 	        MeasurementCharacteristic ON ChannelGroupType.MeasurementCharacteristicID = MeasurementCharacteristic.ID
     ")]
-    [SettingsCategory("systemSettings")]
-    [AllowSearch]
-    [PostRoles("Administrator, Transmission SME")]
-    [PatchRoles("Administrator, Transmission SME")]
-    [DeleteRoles("Administrator, Transmission SME")]
     public class ChannelGroupDetails : ChannelGroupType
     {
         public string ChannelGroup { get; set; }

--- a/Source/Libraries/openXDA.Model/Channels/ChannelGroupType.cs
+++ b/Source/Libraries/openXDA.Model/Channels/ChannelGroupType.cs
@@ -32,6 +32,10 @@ using System.Threading.Tasks;
 namespace openXDA.Model
 {
     [SettingsCategory("systemSettings")]
+    [AllowSearch]
+    [PostRoles("Administrator, Transmission SME")]
+    [PatchRoles("Administrator, Transmission SME")]
+    [DeleteRoles("Administrator, Transmission SME")]
     public class ChannelGroupType
     {
         [PrimaryKey(true)]
@@ -61,6 +65,10 @@ namespace openXDA.Model
 	        MeasurementCharacteristic ON ChannelGroupType.MeasurementCharacteristicID = MeasurementCharacteristic.ID
     ")]
     [SettingsCategory("systemSettings")]
+    [AllowSearch]
+    [PostRoles("Administrator, Transmission SME")]
+    [PatchRoles("Administrator, Transmission SME")]
+    [DeleteRoles("Administrator, Transmission SME")]
     public class ChannelGroupDetails : ChannelGroupType
     {
         public string ChannelGroup { get; set; }


### PR DESCRIPTION
Update the permissions of ChannelGroupType and ChannelGroupDetails to allow Admins and Transmission SMEs access