### PR TITLE
Remove extra DisplayName selector from ChannelGroupDetails

### DIFF
--- a/Source/Libraries/openXDA.Model/Channels/ChannelGroupType.cs
+++ b/Source/Libraries/openXDA.Model/Channels/ChannelGroupType.cs
@@ -56,8 +56,7 @@ namespace openXDA.Model
 	        ChannelGroupType.*,
 	        ChannelGroup.Name as ChannelGroup,
 	        MeasurementType.Name as MeasurementType,
-	        MeasurementCharacteristic.Name as MeasurementCharacteristic,
-	        ChannelGroupType.DisplayName
+	        MeasurementCharacteristic.Name as MeasurementCharacteristic
         FROM
 	        ChannelGroupType JOIN 
 	        ChannelGroup ON ChannelGroupType.ChannelGroupID = ChannelGroup.ID JOIN 


### PR DESCRIPTION
Remove extra DisplayName selector from ChannelGroupDetails which causes a duplicate DisplayName column