### PR TITLE
Avoid exceptions in ToCycleDataGroup for short waveform captures

### DIFF
--- a/Source/Libraries/FaultData/DataAnalysis/Transform.cs
+++ b/Source/Libraries/FaultData/DataAnalysis/Transform.cs
@@ -75,6 +75,10 @@ namespace FaultData.DataAnalysis
 
             //preinitialize size of SeriesInfo
             int ncycleData = dataSeries.DataPoints.Count - samplesPerCycle + 1;
+
+            if (ncycleData <= 0)
+                return null;
+
             rmsSeries.DataPoints.Capacity = ncycleData;
             phaseSeries.DataPoints.Capacity = ncycleData;
             peakSeries.DataPoints.Capacity = ncycleData;


### PR DESCRIPTION
I saw a bunch of the following errors in HECO's production system, with the stack trace pointing to the `Transform.ToCycleDataGroup()` method.

> `System.ArgumentOutOfRangeException: capacity was less than the current size.`

Since these `DataSeries` have just been created, their `DataPoints` collections should be empty. Playing around with a test app, I confirmed that this exception gets thrown when you attempt to set capacity to a negative value. It suggests that the waveform captures are less than one full cycle, in which case we cannot compute any cycle data for that waveform.

This bounds check also includes capacity of zero since it would be pointless to continue when we know that no cycle data will be produced.