### PR TITLE
Fix null reference exceptions in email chart generation Ticket_1517

### DIFF
--- a/Source/Libraries/FaultData/DataWriters/ChartGenerator.cs
+++ b/Source/Libraries/FaultData/DataWriters/ChartGenerator.cs
@@ -88,6 +88,7 @@ namespace FaultData.DataWriters
         public Chart GenerateChart(string title, List<string> keys, List<string> names, DateTime startTime, DateTime endTime, int minSamplesPerCycle = -1)
         {
             List<DataSeries> dataSeriesList;
+            int dataEndIndex;
 
             Chart chart;
             ChartArea area;
@@ -105,8 +106,13 @@ namespace FaultData.DataWriters
 
             // Snap startTime and endTime
             // to the data's time boundaries
+            dataEndIndex = dataSeriesList
+                .Where(dataSeries => !(dataSeries is null))
+                .Select(dataSeries => dataSeries.DataPoints.Count - 1)
+                .FirstOrDefault();
+
             dataStart = ToDateTime(0);
-            dataEnd = ToDateTime(dataSeriesList[0].DataPoints.Count - 1);
+            dataEnd = ToDateTime(dataEndIndex);
 
             if (startTime < dataStart)
                 startTime = dataStart;
@@ -170,7 +176,7 @@ namespace FaultData.DataWriters
             DateTime dateTime;
 
             dateTime = m_seriesLookup
-                .Where(kvp => kvp.Value.IsValueCreated)
+                .Where(kvp => kvp.Value.IsValueCreated && !(kvp.Value.Value is null))
                 .Select(kvp => kvp.Value.Value[index].Time)
                 .FirstOrDefault();
 


### PR DESCRIPTION
Add checks for null values when a single-phase fault is computed using a device that doesn't have all phases of current wired in.