### PR TITLE
Push cyclic histogram data into InfluxDB

### DIFF
--- a/Source/Applications/openXDA/openXDA/ServiceHost.cs
+++ b/Source/Applications/openXDA/openXDA/ServiceHost.cs
@@ -77,6 +77,7 @@ using System.Net.Http;
 using System.ServiceProcess;
 using System.Text;
 using System.Threading.Tasks;
+using FaultData;
 using GSF;
 using GSF.Configuration;
 using GSF.Console;

--- a/Source/Applications/openXDA/openXDA/openXDA.csproj
+++ b/Source/Applications/openXDA/openXDA/openXDA.csproj
@@ -136,8 +136,8 @@
     <Reference Include="GSF.Web">
       <HintPath>..\..\..\Dependencies\GSF\GSF.Web.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Dependencies\NuGet\HIDS.1.0.5\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\Dependencies\NuGet\HIDS.1.1.0\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Applications/openXDA/openXDA/packages.config
+++ b/Source/Applications/openXDA/openXDA/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.2.1" targetFramework="net48" />
-  <package id="HIDS" version="1.0.5" targetFramework="net48" />
+  <package id="HIDS" version="1.1.0" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/Source/Data/05 - DefaultSettings.sql
+++ b/Source/Data/05 - DefaultSettings.sql
@@ -242,6 +242,9 @@ GO
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('FileProcessor.FilePattern', '(?<AssetKey>[^\\]+)\\[^\\]+$', '(?<AssetKey>[^\\]+)\\[^\\]+$')
 GO
 
+INSERT INTO Setting(Name, Value, DefaultValue) VALUES('FileProcessor.FileGroupingPattern', '^(?<FileGroupKey>.*)\.[^\.]*$', '^(?<FileGroupKey>.*)\.[^\.]*$')
+GO
+
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('FileProcessor.MaxFileCreationTimeOffset', '0.0', '0.0')
 GO
 
@@ -261,6 +264,9 @@ INSERT INTO Setting(Name, Value, DefaultValue) VALUES('FileWatcher.InternalThrea
 GO
 
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('FileWatcher.WatchDirectories', 'Watch', 'Watch')
+GO
+
+INSERT INTO Setting(Name, Value, DefaultValue) VALUES('HIDS.HistogramBucket', 'histogram_bucket', 'histogram_bucket')
 GO
 
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('HIDS.Host', '', '')

--- a/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
@@ -754,6 +754,9 @@ namespace FaultData.DataOperations
                     }
                 }
 
+                if (parsedMeter.Channels is null)
+                    return;
+
                 IEnumerable<ChannelKey> parsedChannelKeys = parsedMeter.Channels
                     .Concat(allDataSeries.Select(dataSeries => dataSeries.SeriesInfo.Channel))
                     .Where(channel => (object)channel.Asset != null)

--- a/Source/Libraries/FaultData/DataReaders/CyclicHistogramReader.cs
+++ b/Source/Libraries/FaultData/DataReaders/CyclicHistogramReader.cs
@@ -1,0 +1,77 @@
+﻿//******************************************************************************************************
+//  CyclicHistogramReader.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  09/15/2023 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.IO;
+using System.Linq;
+using FaultData.DataSets;
+using openXDA.Model;
+
+namespace FaultData.DataReaders
+{
+    public class CyclicHistogramReader : IDataReader
+    {
+        public bool IsReadyForLoad(FileInfo[] fileList) =>
+            fileList.Any(fileInfo => IsMetadataFile(fileInfo.Name)) &&
+            fileList.Any(fileInfo => IsDataFile(fileInfo.Name));
+
+        public DataFile GetMetadataFile(FileGroup fileGroup) =>
+            fileGroup.DataFiles.FirstOrDefault(dataFile => IsMetadataFile(dataFile.FilePath));
+
+        public DataFile GetPrimaryDataFile(FileGroup fileGroup) =>
+            fileGroup.DataFiles.FirstOrDefault(dataFile => IsDataFile(dataFile.FilePath));
+
+        public MeterDataSet Parse(FileGroup fileGroup)
+        {
+            DataFile metadataFile = GetMetadataFile(fileGroup);
+            DataFile dataFile = GetPrimaryDataFile(fileGroup);
+            CyclicHistogramDataSet.MetadataSet metadata = ParseMetadata(metadataFile);
+            CyclicHistogramDataSet histogramDataSet = ParseHistogramData(metadata, dataFile);
+            return CreateMeterDataSet(histogramDataSet);
+        }
+
+        private CyclicHistogramDataSet.MetadataSet ParseMetadata(DataFile metadataFile)
+        {
+            using (MemoryStream metadataStream = new MemoryStream(metadataFile.FileBlob.Blob))
+                return CyclicHistogramDataSet.LoadMetadata(metadataStream);
+        }
+
+        private CyclicHistogramDataSet ParseHistogramData(CyclicHistogramDataSet.MetadataSet metadata, DataFile dataFile)
+        {
+            using (MemoryStream metadataStream = new MemoryStream(dataFile.FileBlob.Blob))
+                return CyclicHistogramDataSet.LoadAllHistograms(metadata, metadataStream);
+        }
+
+        private MeterDataSet CreateMeterDataSet(CyclicHistogramDataSet histogramDataSet) => new MeterDataSet()
+        {
+            CyclicHistogramDataSet = histogramDataSet,
+            Meter = new Meter()
+        };
+
+        private bool IsMetadataFile(string filePath) =>
+            filePath.EndsWith("MD.csv", StringComparison.OrdinalIgnoreCase);
+
+        private bool IsDataFile(string filePath) =>
+            filePath.EndsWith(".bin", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Source/Libraries/FaultData/DataSets/CyclicHistogramDataSet.cs
+++ b/Source/Libraries/FaultData/DataSets/CyclicHistogramDataSet.cs
@@ -1,0 +1,317 @@
+﻿//******************************************************************************************************
+//  CyclicHistogramDataSet.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  09/15/2023 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace FaultData.DataSets
+{
+    public class CyclicHistogramDataSet
+    {
+        #region [ Members ]
+
+        // Nested Types
+        public class MetadataSet
+        {
+            public string DFRName { get; set; }
+            public string ChannelName { get; set; }
+            public string ChannelPhase { get; set; }
+            public string ChannelLineName { get; set; }
+            public int FundamentalFrequency { get; set; }
+            public int SamplingRate { get; set; }
+            public TimeSpan StartTime { get; set; }
+            public TimeSpan EndTime { get; set; }
+            public int TotalCapturedCycles { get; set; }
+            public double CyclesMax { get; set; }
+            public double CyclesMin { get; set; }
+            public double ResidualMax { get; set; }
+            public double ResidualMin { get; set; }
+            public double FrequencyMax { get; set; }
+            public double FrequencyMin { get; set; }
+            public double RMSMax { get; set; }
+            public double RMSMin { get; set; }
+            public int CyclicHistogramBins { get; set; }
+            public int ResidualHistogramBins { get; set; }
+            public int FrequencyHistogramBins { get; set; }
+            public string DataPrecision { get; set; }
+            public DateTime RecordDate { get; set; }
+            public string TimeZone { get; set; }
+        }
+
+        public class DataPoint
+        {
+            public int Bin { get; }
+            public int Sample { get; }
+            public float Value { get; }
+
+            public DataPoint(int bin, int sample, float value)
+            {
+                Bin = bin;
+                Sample = sample;
+                Value = value;
+            }
+        }
+
+        // Delegates
+        private delegate void MetadataLoadAction(MetadataSet metadata, string fieldName, string value);
+
+        #endregion
+
+        #region [ Constructors ]
+
+        private CyclicHistogramDataSet(MetadataSet metadata, List<DataPoint> cyclicHistogram, List<DataPoint> residualHistogram, List<DataPoint> frequencyHistogram, List<DataPoint> rmsHistogram, int rmsHistogramBins)
+        {
+            Metadata = metadata;
+            CyclicHistogram = cyclicHistogram;
+            ResidualHistogram = residualHistogram;
+            FrequencyHistogram = frequencyHistogram;
+            RMSHistogram = rmsHistogram;
+            RMSHistogramBins = rmsHistogramBins;
+        }
+
+        #endregion
+
+        #region [ Properties ]
+
+        public MetadataSet Metadata { get; }
+        public List<DataPoint> CyclicHistogram { get; }
+        public List<DataPoint> ResidualHistogram { get; }
+        public List<DataPoint> FrequencyHistogram { get; }
+        public List<DataPoint> RMSHistogram { get; }
+        public int RMSHistogramBins { get; }
+
+        #endregion
+
+        #region [ Static ]
+
+        // Static Properties
+        private static MetadataLoadAction MetadataLoader { get; }
+            = InitializeMetadataLoader();
+
+        // Static Methods
+        public static MetadataSet LoadMetadata(string filePath)
+        {
+            using (Stream stream = File.OpenRead(filePath))
+            {
+                return LoadMetadata(stream);
+            }
+        }
+
+        public static MetadataSet LoadMetadata(Stream stream)
+        {
+            Encoding encoding = new UTF8Encoding(false);
+
+            using (TextReader reader = new StreamReader(stream, encoding, false, 4096, true))
+            {
+                return LoadMetadata(reader);
+            }
+        }
+
+        public static MetadataSet LoadMetadata(TextReader reader)
+        {
+            MetadataSet metadata = new MetadataSet();
+
+            while (true)
+            {
+                string line = reader.ReadLine();
+                if (line is null)
+                    return metadata;
+
+                int commaIndex = line.IndexOf(',');
+                if (commaIndex == -1)
+                    continue;
+
+                string fieldName = line.Substring(0, commaIndex);
+                string value = line.Substring(commaIndex + 1);
+                MetadataLoader.Invoke(metadata, fieldName, value);
+            }
+        }
+
+        public static CyclicHistogramDataSet LoadAllHistograms(MetadataSet metadata, string filePath)
+        {
+            using (Stream stream = File.OpenRead(filePath))
+            {
+                return LoadAllHistograms(metadata, stream);
+            }
+        }
+
+        public static CyclicHistogramDataSet LoadAllHistograms(MetadataSet metadata, Stream stream) =>
+            LoadAllHistograms(metadata, stream, (int)stream.Length);
+
+        public static CyclicHistogramDataSet LoadAllHistograms(MetadataSet metadata, Stream stream, int totalBytes)
+        {
+            using (BinaryReader reader = new BinaryReader(stream, Encoding.Default, true))
+            {
+                return LoadAllHistograms(metadata, reader, totalBytes);
+            }
+        }
+
+        public static CyclicHistogramDataSet LoadAllHistograms(MetadataSet metadata, BinaryReader reader) =>
+            LoadAllHistograms(metadata, reader, (int)reader.BaseStream.Length);
+
+        public static CyclicHistogramDataSet LoadAllHistograms(MetadataSet metadata, BinaryReader reader, int totalBytes)
+        {
+            int GetValueSize(string dataType)
+            {
+                switch (dataType)
+                {
+                    case "float32": return sizeof(float);
+                    default: throw new InvalidDataException($"Unknown data type: {dataType}");
+                }
+            }
+
+            float LoadValue()
+            {
+                switch (metadata.DataPrecision)
+                {
+                    case "float32": return reader.ReadSingle();
+                    default: throw new InvalidDataException($"Unknown data type: {metadata.DataPrecision}");
+                }
+            }
+
+            int samplesPerCycle = metadata.SamplingRate / metadata.FundamentalFrequency;
+
+            int valueSize = GetValueSize(metadata.DataPrecision);
+            int cyclicHistogramByteSize = (samplesPerCycle + 1) * metadata.CyclicHistogramBins * valueSize;
+            int residualHistogramByteSize = (samplesPerCycle + 1) * metadata.ResidualHistogramBins * valueSize;
+            int frequencyHistogramByteSize = metadata.FrequencyHistogramBins * valueSize;
+            int rmsHistogramByteSize = totalBytes - cyclicHistogramByteSize - residualHistogramByteSize - frequencyHistogramByteSize;
+            int rmsHistogramBins = rmsHistogramByteSize / valueSize;
+
+            List<DataPoint> cyclicHistogram = LoadHistogram(samplesPerCycle + 1, metadata.CyclicHistogramBins, LoadValue);
+            List<DataPoint> residualHistogram = LoadHistogram(samplesPerCycle + 1, metadata.ResidualHistogramBins, LoadValue);
+            List<DataPoint> frequencyHistogram = LoadHistogram(1, metadata.FrequencyHistogramBins, LoadValue);
+            List<DataPoint> rmsHistogram = LoadHistogram(1, rmsHistogramBins, LoadValue);
+            return new CyclicHistogramDataSet(metadata, cyclicHistogram, residualHistogram, frequencyHistogram, rmsHistogram, rmsHistogramBins);
+        }
+
+        private static List<DataPoint> LoadHistogram(int binSize, int binCount, Func<float> loadValueFunc)
+        {
+            List<DataPoint> histogram = new List<DataPoint>();
+
+            for (int binIndex = 0; binIndex < binCount; binIndex++)
+            {
+                for (int sampleIndex = 0; sampleIndex < binSize; sampleIndex++)
+                {
+                    float value = loadValueFunc();
+                    if (value == 0.0F)
+                        continue;
+                    DataPoint bin = new DataPoint(binIndex, sampleIndex, value);
+                    histogram.Add(bin);
+                }
+            }
+
+            return histogram;
+        }
+
+        private static MetadataLoadAction InitializeMetadataLoader()
+        {
+            const string DFRNameField = "DFR Name";
+            const string ChannelNameField = "Channel Name";
+            const string ChannelPhaseField = "Channel Phase";
+            const string ChannelLineNameField = "Channel Line Name";
+            const string FundamentalFrequencyField = "Fundamental Frequency";
+            const string SamplingRateField = "Sampling Rate";
+            const string StartTimeField = "Start Time";
+            const string EndTimeField = "End Time";
+            const string TotalCapturedCyclesField = "Total Captured Cycles";
+            const string CyclesMaxField = "Cycles Max";
+            const string CyclesMinField = "Cycles Min";
+            const string ResidualMaxField = "Residual Max";
+            const string ResidualMinField = "Residual Min";
+            const string FrequencyMaxField = "Frequency Max";
+            const string FrequencyMinField = "Frequency Min";
+            const string RMSMaxField = "RMS Max";
+            const string RMSMinField = "RMS Min";
+            const string CyclicHistogramBinsField = "Cyclic Histogram Bins";
+            const string ResidualHistogramBinsField = "Residual Histogram Bins";
+            const string FrequencyHistogramBinsField = "Frequency Histogram Bins";
+            const string DataPercisionField = "Data Percision";
+            const string DataPrecisionField = "Data Precision";
+            const string RecordDateField = "Record Date";
+            const string TimeZoneField = "Time Zone";
+
+            Action<MetadataSet, string> LoadTime(Action<MetadataSet, TimeSpan> loader) => (metadata, value) =>
+            {
+                if (TimeSpan.TryParse(value, out TimeSpan num))
+                    loader(metadata, num);
+            };
+
+            Action<MetadataSet, string> LoadDate(Action<MetadataSet, DateTime> loader) => (metadata, value) =>
+            {
+                if (DateTime.TryParse(value, out DateTime num))
+                    loader(metadata, num);
+            };
+
+            Action<MetadataSet, string> LoadInteger(Action<MetadataSet, int> loader) => (metadata, value) =>
+            {
+                if (int.TryParse(value, out int num))
+                    loader(metadata, num);
+            };
+
+            Action<MetadataSet, string> LoadDouble(Action<MetadataSet, double> loader) => (metadata, value) =>
+            {
+                if (double.TryParse(value, out double num))
+                    loader(metadata, num);
+            };
+
+            Dictionary<string, Action<MetadataSet, string>> lookup = new Dictionary<string, Action<MetadataSet, string>>()
+            {
+                { DFRNameField, (metadata, value) => metadata.DFRName = value },
+                { ChannelNameField, (metadata, value) => metadata.ChannelName = value },
+                { ChannelPhaseField, (metadata, value) => metadata.ChannelPhase = value },
+                { ChannelLineNameField, (metadata, value) => metadata.ChannelLineName = value },
+                { FundamentalFrequencyField, LoadInteger((metadata, value) => metadata.FundamentalFrequency = value) },
+                { SamplingRateField, LoadInteger((metadata, value) => metadata.SamplingRate = value) },
+                { StartTimeField, LoadTime((metadata, value) => metadata.StartTime = value) },
+                { EndTimeField, LoadTime((metadata, value) => metadata.EndTime = value) },
+                { TotalCapturedCyclesField, LoadInteger((metadata, value) => metadata.TotalCapturedCycles = value) },
+                { CyclesMaxField, LoadDouble((metadata, value) => metadata.CyclesMax = value) },
+                { CyclesMinField, LoadDouble((metadata, value) => metadata.CyclesMin = value) },
+                { ResidualMaxField, LoadDouble((metadata, value) => metadata.ResidualMax = value) },
+                { ResidualMinField, LoadDouble((metadata, value) => metadata.ResidualMin = value) },
+                { FrequencyMaxField, LoadDouble((metadata, value) => metadata.FrequencyMax = value) },
+                { FrequencyMinField, LoadDouble((metadata, value) => metadata.FrequencyMin = value) },
+                { RMSMaxField, LoadDouble((metadata, value) => metadata.RMSMax = value) },
+                { RMSMinField, LoadDouble((metadata, value) => metadata.RMSMin = value) },
+                { CyclicHistogramBinsField, LoadInteger((metadata, value) => metadata.CyclicHistogramBins = value) },
+                { ResidualHistogramBinsField, LoadInteger((metadata, value) => metadata.ResidualHistogramBins = value) },
+                { FrequencyHistogramBinsField, LoadInteger((metadata, value) => metadata.FrequencyHistogramBins = value) },
+                { DataPercisionField, (metadata, value) => metadata.DataPrecision = value },
+                { DataPrecisionField, (metadata, value) => metadata.DataPrecision = value },
+                { RecordDateField, LoadDate((metadata, value) => metadata.RecordDate = value) },
+                { TimeZoneField, (metadata, value) => metadata.TimeZone = value },
+            };
+
+            return (metadata, fieldName, value) =>
+            {
+                if (lookup.TryGetValue(fieldName, out Action<MetadataSet, string> loader))
+                    loader(metadata, value);
+            };
+        }
+
+        #endregion
+    }
+}

--- a/Source/Libraries/FaultData/DataSets/MeterDataSet.cs
+++ b/Source/Libraries/FaultData/DataSets/MeterDataSet.cs
@@ -88,6 +88,7 @@ namespace FaultData.DataSets
         private Dictionary<Type, object> Resources { get; set; }
         public BreakerRestrikeDataSet BreakerRestrikeDataSet { get; set; }
         public AnalysisDataSet AnalysisDataSet { get; set; }
+        public CyclicHistogramDataSet CyclicHistogramDataSet { get; set; }
 
         #endregion
 

--- a/Source/Libraries/FaultData/FaultData.csproj
+++ b/Source/Libraries/FaultData/FaultData.csproj
@@ -135,6 +135,7 @@
     <Compile Include="DataOperations\TVA\RealTimeLightningDataOperation.cs" />
     <Compile Include="DataOperations\TVA\RealTimeLightningDataProvider.cs" />
     <Compile Include="DataOperations\TVA\StructureQueryOperation.cs" />
+    <Compile Include="DataReaders\CyclicHistogramReader.cs" />
     <Compile Include="DataReaders\DataReaderFactory.cs" />
     <Compile Include="DataReaders\NullDataReader.cs" />
     <Compile Include="DataReaders\SELLDPReader.cs" />
@@ -162,6 +163,7 @@
     <Compile Include="DataResources\SnapshotDataResource.cs" />
     <Compile Include="DataResources\TransientDataResource.cs" />
     <Compile Include="DataSets\AnalysisDataSet.cs" />
+    <Compile Include="DataSets\CyclicHistogramDataSet.cs" />
     <Compile Include="DataSets\GTC\BreakerRestrikeDataSet.cs" />
     <Compile Include="DataSets\IDataSet.cs" />
     <Compile Include="DataResources\TrendingDataSummaryResource.cs" />
@@ -180,6 +182,7 @@
     <Compile Include="DataWriters\GTC\FTTRecord.cs" />
     <Compile Include="DataWriters\LightningGenerator.cs" />
     <Compile Include="DataWriters\PQIGenerator.cs" />
+    <Compile Include="TimeZoneConverter.cs" />
     <None Include="DataWriters\XMLWriter.cs" />
     <Compile Include="DataSets\MeterDataSet.cs" />
     <Compile Include="DataWriters\StructureLocationGenerator.cs" />

--- a/Source/Libraries/FaultData/TimeZoneConverter.cs
+++ b/Source/Libraries/FaultData/TimeZoneConverter.cs
@@ -26,7 +26,7 @@ using System.ComponentModel;
 using GSF.Configuration;
 using openXDA.Configuration;
 
-namespace openXDA.Nodes
+namespace FaultData
 {
     public class TimeZoneConverter
     {

--- a/Source/Libraries/OpenXDA.NotificationDataSources/openXDA.NotificationDataSources.csproj
+++ b/Source/Libraries/OpenXDA.NotificationDataSources/openXDA.NotificationDataSources.csproj
@@ -46,8 +46,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Dependencies\GSF\GSF.Security.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\HIDS.1.0.5\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\HIDS.1.1.0\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Libraries/OpenXDA.NotificationDataSources/packages.config
+++ b/Source/Libraries/OpenXDA.NotificationDataSources/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.2.1" targetFramework="net48" />
-  <package id="HIDS" version="1.0.5" targetFramework="net48" />
+  <package id="HIDS" version="1.1.0" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/Source/Libraries/SPCTools/SPCTools.csproj
+++ b/Source/Libraries/SPCTools/SPCTools.csproj
@@ -37,8 +37,8 @@
     <Reference Include="GSF.Core">
       <HintPath>..\..\Dependencies\GSF\GSF.Core.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\HIDS.1.0.5\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\HIDS.1.1.0\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Libraries/SPCTools/packages.config
+++ b/Source/Libraries/SPCTools/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.2.1" targetFramework="net48" />
-  <package id="HIDS" version="1.0.5" targetFramework="net48" />
+  <package id="HIDS" version="1.1.0" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/Source/Libraries/openXDA.Adapters/openXDA.Adapters.csproj
+++ b/Source/Libraries/openXDA.Adapters/openXDA.Adapters.csproj
@@ -43,8 +43,8 @@
     <Reference Include="GSF.Web">
       <HintPath>..\..\Dependencies\GSF\GSF.Web.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\HIDS.1.0.5\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\HIDS.1.1.0\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Libraries/openXDA.Adapters/packages.config
+++ b/Source/Libraries/openXDA.Adapters/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.2.1" targetFramework="net48" />
-  <package id="HIDS" version="1.0.5" targetFramework="net48" />
+  <package id="HIDS" version="1.1.0" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/Source/Libraries/openXDA.Configuration/FileProcessorSection.cs
+++ b/Source/Libraries/openXDA.Configuration/FileProcessorSection.cs
@@ -36,8 +36,15 @@ namespace openXDA.Configuration
         /// order to identify the meter that the file came from.
         /// </summary>
         [Setting]
-        [DefaultValue(@"(?<AssetKey>[^\\]+)\\[^\\]+$")]
+        [DefaultValue(/*lang=regex*/ @"(?<AssetKey>[^\\]+)\\[^\\]+$")]
         public string FilePattern { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pattern that identifies the part of the file path that
+        /// </summary>
+        [Setting]
+        [DefaultValue(/*lang=regex*/ @"^(?<FileGroupKey>.*)\.[^\.]*$")]
+        public string FileGroupingPattern { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of hours prior to the current system time

--- a/Source/Libraries/openXDA.HIDS/APIExtensions/APIExtensions.cs
+++ b/Source/Libraries/openXDA.HIDS/APIExtensions/APIExtensions.cs
@@ -40,6 +40,9 @@ namespace openXDA.HIDS.APIExtensions
             if (!string.IsNullOrEmpty(settings.PointBucket))
                 hids.PointBucket = settings.PointBucket;
 
+            if (!string.IsNullOrEmpty(settings.HistogramBucket))
+                hids.HistogramBucket = settings.HistogramBucket;
+
             if (!string.IsNullOrEmpty(settings.OrganizationID))
                 hids.OrganizationID = settings.OrganizationID;
 

--- a/Source/Libraries/openXDA.HIDS/CyclicHistogramOperation.cs
+++ b/Source/Libraries/openXDA.HIDS/CyclicHistogramOperation.cs
@@ -1,0 +1,139 @@
+﻿//******************************************************************************************************
+//  CyclicHistogramOperation.cs - Gbtc
+//
+//  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  10/05/2023 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using FaultData;
+using FaultData.DataOperations;
+using FaultData.DataSets;
+using GSF.Configuration;
+using HIDS;
+using log4net;
+using openXDA.HIDS.APIExtensions;
+using static HIDS.Histogram;
+
+namespace openXDA.HIDS
+{
+    public class CyclicHistogramOperation : DataOperationBase<MeterDataSet>
+    {
+        [Category]
+        [SettingName(HIDSSettings.CategoryName)]
+        public HIDSSettings HIDSSettings { get; } = new HIDSSettings();
+
+        public override void Execute(MeterDataSet meterDataSet)
+        {
+            if (meterDataSet.CyclicHistogramDataSet is null)
+            {
+                Log.Debug($"No cyclic histogram data found; skipping {nameof(CyclicHistogramOperation)}.");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(HIDSSettings.Host))
+            {
+                Log.Debug($"No HIDS instance defined; skipping {nameof(CyclicHistogramOperation)}.");
+                return;
+            }
+
+            string channelName = meterDataSet.CyclicHistogramDataSet.Metadata.ChannelLineName;
+
+            Model.Channel channel = meterDataSet.Meter.Channels
+                .FirstOrDefault(channel => channel.Name == channelName);
+
+            if (channel is null)
+                return;
+
+            TimeZoneConverter timeZoneConverter = new TimeZoneConverter(meterDataSet.Configure);
+            Task executeTask = ExecuteAsync(channel, meterDataSet.CyclicHistogramDataSet, timeZoneConverter);
+            executeTask.GetAwaiter().GetResult();
+        }
+
+        public async Task ExecuteAsync(Model.Channel channel, CyclicHistogramDataSet cyclicHistogramDataSet, TimeZoneConverter timeZoneConverter)
+        {
+            using API hids = new API();
+            await hids.ConfigureAsync(HIDSSettings);
+
+            Histogram histogram = new Histogram();
+            LoadMetadata(histogram.Info, cyclicHistogramDataSet);
+            histogram.Info.Tag = hids.ToTag(channel.ID);
+            histogram.Info.StartTime = timeZoneConverter.ToXDATimeZone(histogram.Info.StartTime);
+            histogram.Info.EndTime = timeZoneConverter.ToXDATimeZone(histogram.Info.EndTime);
+
+            LoadData(histogram.CyclicHistogramData, cyclicHistogramDataSet.CyclicHistogram);
+            LoadData(histogram.ResidualHistogramData, cyclicHistogramDataSet.ResidualHistogram);
+            LoadData(histogram.FrequencyHistogramData, cyclicHistogramDataSet.FrequencyHistogram);
+            LoadData(histogram.RMSHistogramData, cyclicHistogramDataSet.RMSHistogram);
+
+            await hids.WriteHistogramAsync(histogram);
+        }
+
+        private void LoadMetadata(Metadata destination, CyclicHistogramDataSet source)
+        {
+            CyclicHistogramDataSet.MetadataSet sourceMetadata = source.Metadata;
+            TimeSpan timeZoneOffset = ParseTimeZoneOffset(sourceMetadata.TimeZone);
+            destination.FundamentalFrequency = sourceMetadata.FundamentalFrequency;
+            destination.SamplingRate = sourceMetadata.SamplingRate;
+            destination.StartTime = sourceMetadata.RecordDate + sourceMetadata.StartTime - timeZoneOffset;
+            destination.EndTime = sourceMetadata.RecordDate + sourceMetadata.EndTime - timeZoneOffset;
+            destination.TotalCapturedCycles = sourceMetadata.TotalCapturedCycles;
+            destination.CyclesMax = sourceMetadata.CyclesMax;
+            destination.CyclesMin = sourceMetadata.CyclesMin;
+            destination.ResidualMax = sourceMetadata.ResidualMax;
+            destination.ResidualMin = sourceMetadata.ResidualMin;
+            destination.FrequencyMax = sourceMetadata.FrequencyMax;
+            destination.FrequencyMin = sourceMetadata.FrequencyMin;
+            destination.RMSMax = sourceMetadata.RMSMax;
+            destination.RMSMin = sourceMetadata.RMSMin;
+            destination.CyclicHistogramBins = sourceMetadata.CyclicHistogramBins;
+            destination.ResidualHistogramBins = sourceMetadata.ResidualHistogramBins;
+            destination.FrequencyHistogramBins = sourceMetadata.FrequencyHistogramBins;
+            destination.RMSHistogramBins = source.RMSHistogramBins;
+        }
+
+        private void LoadData(List<Histogram.Point> destination, List<CyclicHistogramDataSet.DataPoint> source)
+        {
+            foreach (CyclicHistogramDataSet.DataPoint dataPoint in source)
+            {
+                Histogram.Point point = new Histogram.Point();
+                point.Bin = dataPoint.Bin;
+                point.Sample = dataPoint.Sample;
+                point.Value = dataPoint.Value;
+                destination.Add(point);
+            }
+        }
+
+        private TimeSpan ParseTimeZoneOffset(string timeZoneOffset)
+        {
+            string trimmedTimeZoneOffset = timeZoneOffset.EndsWith("t")
+                ? timeZoneOffset.Substring(0, timeZoneOffset.Length - 1)
+                : timeZoneOffset;
+
+            return double.TryParse(trimmedTimeZoneOffset, out double offset)
+                ? TimeSpan.FromHours(offset) : TimeSpan.Zero;
+        }
+
+        private static readonly ILog Log = LogManager.GetLogger(typeof(CyclicHistogramDataSet));
+    }
+}

--- a/Source/Libraries/openXDA.HIDS/HIDSSettings.cs
+++ b/Source/Libraries/openXDA.HIDS/HIDSSettings.cs
@@ -43,6 +43,10 @@ namespace openXDA.HIDS
         public string PointBucket { get; set; }
 
         [Setting]
+        [DefaultValue("histogram_bucket")]
+        public string HistogramBucket { get; set; }
+
+        [Setting]
         [DefaultValue("gpa")]
         public string OrganizationID { get; set; }
     }

--- a/Source/Libraries/openXDA.HIDS/openXDA.HIDS.csproj
+++ b/Source/Libraries/openXDA.HIDS/openXDA.HIDS.csproj
@@ -38,8 +38,8 @@
     <Reference Include="GSF.Core">
       <HintPath>..\..\Dependencies\GSF\GSF.Core.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\HIDS.1.0.5\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\HIDS.1.1.0\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>
@@ -185,6 +185,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CyclicHistogramOperation.cs" />
     <Compile Include="HIDSAlarmOperation.cs" />
     <Compile Include="APIExtensions\APIExtensions.cs" />
     <Compile Include="DailySummaryOperation.cs" />

--- a/Source/Libraries/openXDA.HIDS/packages.config
+++ b/Source/Libraries/openXDA.HIDS/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.2.1" targetFramework="net48" />
-  <package id="HIDS" version="1.0.5" targetFramework="net48" />
+  <package id="HIDS" version="1.1.0" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisNode.cs
@@ -47,7 +47,6 @@ using GSF.Threading;
 using log4net;
 using openXDA.Configuration;
 using openXDA.Model;
-using SystemCenter.Model;
 using IDataReader = FaultData.DataReaders.IDataReader;
 
 namespace openXDA.Nodes.Types.Analysis

--- a/Source/Libraries/openXDA.Nodes/Types/Email/EventEmailNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/Email/EventEmailNode.cs
@@ -31,6 +31,7 @@ using System.Text;
 using System.Threading;
 using System.Web.Http;
 using System.Web.Http.Controllers;
+using FaultData;
 using FaultData.DataOperations;
 using FaultData.DataWriters.Emails;
 using GSF.Configuration;

--- a/Source/Libraries/openXDA.Nodes/Types/Email/ScheduledEmailNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/Email/ScheduledEmailNode.cs
@@ -30,6 +30,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.Controllers;
+using FaultData;
 using FaultData.DataWriters.Emails;
 using GSF.Configuration;
 using GSF.Data;

--- a/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileProcessingTask.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileProcessingTask.cs
@@ -27,6 +27,7 @@ using System.Data;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using FaultData;
 using FaultData.DataReaders;
 using GSF.Collections;
 using GSF.Configuration;
@@ -224,16 +225,9 @@ namespace openXDA.Nodes.Types.FileProcessing
 
             try
             {
-                string directory = Path.GetDirectoryName(FilePath);
-                DirectoryInfo directoryInfo = new DirectoryInfo(directory);
-
-                string fileName = Path.GetFileName(FilePath);
-                string searchPattern = Path.ChangeExtension(fileName, ".*");
-                FileInfo[] fileList = directoryInfo.GetFiles(searchPattern);
-
                 FileGroup fileGroup = new FileGroup();
                 fileGroup.MeterID = meterID;
-                fileGroup.DataFiles = fileList.Select(ToDataFile).ToList();
+                fileGroup.DataFiles = FileList.Select(ToDataFile).ToList();
                 return fileGroup;
             }
             catch (IOException)

--- a/Source/Libraries/openXDA.Nodes/openXDA.Nodes.csproj
+++ b/Source/Libraries/openXDA.Nodes/openXDA.Nodes.csproj
@@ -92,7 +92,6 @@
     <Compile Include="Types\FileProcessing\FileSkippedException.cs" />
     <Compile Include="Host.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TimeZoneConverter.cs" />
     <Compile Include="Types\FilePruning\FilePrunerNode.cs" />
     <Compile Include="INode.cs" />
     <Compile Include="NodeBase.cs" />
@@ -117,10 +116,6 @@
     <ProjectReference Include="..\openXDA.Model\openXDA.Model.csproj">
       <Project>{a1a0bc13-50ed-4dc9-8c1e-3293b0b69281}</Project>
       <Name>openXDA.Model</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\OpenXDA.NotificationDataSources\openXDA.NotificationDataSources.csproj">
-      <Project>{2813A92F-8CB5-4EC3-976C-8690C90C6DD0}</Project>
-      <Name>openXDA.NotificationDataSources</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
@gcsantos-gpa This is the last step. No major rush on this--feel free to merge when you're ready to work on SEBrowser. I'll get a histogram uploaded into the demo system in the meantime.

* Introduce `CyclicHistogramDataSet`, `CyclicHistogramReader`, and `CyclicHistogramOperation` to read the data and push it to InfluxDB via the HIDS API.
* Add API calls to `HIDSController` to query histograms from InfluxDB.
* Update file processor index to group files based on a regex.
* Fix bug in `FileProcessingTask` where it wasn't using the file processor index to group files but was instead scanning the folder again.
* Move `TimeZoneConverter` to `FaultData` to avoid cyclic dependencies.
* Fix `NullReferenceException` in `ConfigurationOperation` when a data reader produces a meter data set with no channels. This also prevents the cyclic histogram data set from affecting the `Enabled` state of the meter's channels.