### PR TITLE
Add parameter to ignore certificate errors when querying FTT

### DIFF
--- a/Source/Libraries/FaultData/DataWriters/GTC/FTTImageGenerator.cs
+++ b/Source/Libraries/FaultData/DataWriters/GTC/FTTImageGenerator.cs
@@ -49,6 +49,7 @@ namespace FaultData.DataWriters.GTC
             URL = options.URL;
             QueryStringFormat = options.QueryStringFormat;
             QueryTimeout = options.QueryTimeout;
+            IgnoreCertificateErrors = options.IgnoreCertificateErrors;
 
             ImageWidth = options.ImageWidth;
             ImageHeight = options.ImageHeight;
@@ -62,6 +63,7 @@ namespace FaultData.DataWriters.GTC
         private string URL { get; }
         private string QueryStringFormat { get; }
         private TimeSpan QueryTimeout { get; }
+        public bool IgnoreCertificateErrors { get; }
 
         private int ImageWidth { get; }
         private int ImageHeight { get; }
@@ -133,6 +135,7 @@ namespace FaultData.DataWriters.GTC
                 string[] fttArguments =
                 {
                     Escape(url).QuoteWrap(),
+                    IgnoreCertificateErrors.ToString(CultureInfo.InvariantCulture),
                     ImageWidth.ToString(CultureInfo.InvariantCulture),
                     ImageHeight.ToString(CultureInfo.InvariantCulture),
                     QueryTimeout.TotalSeconds.ToString(CultureInfo.InvariantCulture),
@@ -233,6 +236,7 @@ namespace FaultData.DataWriters.GTC
 
             string url = (string)fttElement.Attribute("url");
             string queryStringFormat = (string)fttElement.Attribute("queryStringFormat");
+            string ignoreCertificateErrors = (string)fttElement.Attribute("ignoreCertificateErrors");
             string fttWidth = (string)fttElement.Attribute("width");
             string fttHeight = (string)fttElement.Attribute("height");
 
@@ -247,6 +251,7 @@ namespace FaultData.DataWriters.GTC
             options.QueryTimeout = queryTimeout;
             options.URL = url;
             options.QueryStringFormat = queryStringFormat;
+            options.IgnoreCertificateErrors = ignoreCertificateErrors.ParseBoolean();
             options.ImageWidth = imageWidth;
             options.ImageHeight = imageHeight;
 

--- a/Source/Libraries/FaultData/DataWriters/GTC/FTTOptions.cs
+++ b/Source/Libraries/FaultData/DataWriters/GTC/FTTOptions.cs
@@ -31,6 +31,7 @@ namespace FaultData.DataWriters.GTC
         public string URL { get; set; }
         public string QueryStringFormat { get; set; }
         public TimeSpan QueryTimeout { get; set; }
+        public bool IgnoreCertificateErrors { get; set; }
 
         public int ImageWidth { get; set; }
         public int ImageHeight { get; set; }

--- a/Source/Tools/FaultTraceToolInterop/Program.cs
+++ b/Source/Tools/FaultTraceToolInterop/Program.cs
@@ -97,29 +97,26 @@ namespace FaultTraceToolInterop
 
             try
             {
-                if (args.Length < 6)
-                {
+                if (args.Length < 7)
                     throw new Exception("Invalid number of arguments");
-                }
+
                 builder = new UriBuilder(args[1]);
 
-                if (!Int32.TryParse(args[2], out Int32 width))
-                {
+                if (!bool.TryParse(args[2], out bool ignoreCertificateErrors))
+                    ignoreCertificateErrors = false;
+
+                if (!int.TryParse(args[3], out int width))
                     throw new Exception("Invalid Width Parameter");
-                }
-                if (!Int32.TryParse(args[3], out Int32 height))
-                {
+
+                if (!int.TryParse(args[4], out int height))
                     throw new Exception("Invalid Height Parameter");
-                }
-                if (Int32.TryParse(args[4], out Int32 toSecs))
-                {
+
+                if (int.TryParse(args[5], out int toSecs))
                     timeout = new TimeSpan(0, 0, toSecs);
-                }
                 else
-                {
                     throw new Exception("Invalid Timeout Parameter");
-                }
-                filename = args[5];
+
+                filename = args[6];
 
                 long now = DateTime.UtcNow.Ticks;
                 string nocache = $"nocache={now:X}";
@@ -130,7 +127,8 @@ namespace FaultTraceToolInterop
                 builder.Query = string.Join("&", queryParts);
                 var settings = new CefSettings()
                 {
-                    CachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "FTTAPI", "Cache")
+                    CachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "FTTAPI", "Cache"),
+                    IgnoreCertificateErrors = ignoreCertificateErrors
                 };
 
                 Cef.Initialize(settings, performDependencyCheck: true, browserProcessHandler: null);


### PR DESCRIPTION
SOCO is having trouble querying FTT from openXDA. The domain name that matches their certificate routes through a proxy that requires Windows Authentication, and `https://localhost` fails with `CERT_COMMON_NAME_INVALID`. They would like to use `https://localhost` and ignore the certificate errors.