### PR TITLE
Update HIDS to 1.1.1

### DIFF
--- a/Source/Applications/openXDA/openXDA/openXDA.csproj
+++ b/Source/Applications/openXDA/openXDA/openXDA.csproj
@@ -140,8 +140,8 @@
     <Reference Include="GSF.Web">
       <HintPath>..\..\..\Dependencies\GSF\GSF.Web.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Dependencies\NuGet\HIDS.1.1.0\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\Dependencies\NuGet\HIDS.1.1.1\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Applications/openXDA/openXDA/packages.config
+++ b/Source/Applications/openXDA/openXDA/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.2.1" targetFramework="net48" />
-  <package id="HIDS" version="1.1.0" targetFramework="net48" />
+  <package id="HIDS" version="1.1.1" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/Source/Libraries/OpenXDA.NotificationDataSources/openXDA.NotificationDataSources.csproj
+++ b/Source/Libraries/OpenXDA.NotificationDataSources/openXDA.NotificationDataSources.csproj
@@ -46,8 +46,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Dependencies\GSF\GSF.Security.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\HIDS.1.1.0\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\HIDS.1.1.1\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Libraries/OpenXDA.NotificationDataSources/packages.config
+++ b/Source/Libraries/OpenXDA.NotificationDataSources/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.2.1" targetFramework="net48" />
-  <package id="HIDS" version="1.1.0" targetFramework="net48" />
+  <package id="HIDS" version="1.1.1" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/Source/Libraries/SPCTools/SPCTools.csproj
+++ b/Source/Libraries/SPCTools/SPCTools.csproj
@@ -40,8 +40,8 @@
     <Reference Include="GSF.Core">
       <HintPath>..\..\Dependencies\GSF\GSF.Core.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\HIDS.1.1.0\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\HIDS.1.1.1\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Libraries/SPCTools/packages.config
+++ b/Source/Libraries/SPCTools/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.2.1" targetFramework="net48" />
-  <package id="HIDS" version="1.1.0" targetFramework="net48" />
+  <package id="HIDS" version="1.1.1" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/Source/Libraries/openXDA.Adapters/openXDA.Adapters.csproj
+++ b/Source/Libraries/openXDA.Adapters/openXDA.Adapters.csproj
@@ -43,8 +43,8 @@
     <Reference Include="GSF.Web">
       <HintPath>..\..\Dependencies\GSF\GSF.Web.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\HIDS.1.1.0\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\HIDS.1.1.1\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Libraries/openXDA.Adapters/packages.config
+++ b/Source/Libraries/openXDA.Adapters/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.2.1" targetFramework="net48" />
-  <package id="HIDS" version="1.1.0" targetFramework="net48" />
+  <package id="HIDS" version="1.1.1" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />

--- a/Source/Libraries/openXDA.HIDS/openXDA.HIDS.csproj
+++ b/Source/Libraries/openXDA.HIDS/openXDA.HIDS.csproj
@@ -38,8 +38,8 @@
     <Reference Include="GSF.Core">
       <HintPath>..\..\Dependencies\GSF\GSF.Core.dll</HintPath>
     </Reference>
-    <Reference Include="HIDS, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\HIDS.1.1.0\lib\netstandard2.0\HIDS.dll</HintPath>
+    <Reference Include="HIDS, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\HIDS.1.1.1\lib\netstandard2.0\HIDS.dll</HintPath>
     </Reference>
     <Reference Include="InfluxDB.Client, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2ffdb0e6ebde0d3f, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\InfluxDB.Client.3.2.0\lib\netstandard2.0\InfluxDB.Client.dll</HintPath>

--- a/Source/Libraries/openXDA.HIDS/packages.config
+++ b/Source/Libraries/openXDA.HIDS/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="27.2.1" targetFramework="net48" />
-  <package id="HIDS" version="1.1.0" targetFramework="net48" />
+  <package id="HIDS" version="1.1.1" targetFramework="net48" />
   <package id="InfluxDB.Client" version="3.2.0" targetFramework="net48" />
   <package id="InfluxDB.Client.Core" version="3.2.0" targetFramework="net48" />
   <package id="JsonSubTypes" version="1.8.0" targetFramework="net48" />


### PR DESCRIPTION
Fixes the issue where `fundamentalFrequency` and `samplingRate` were not being written to InfluxDB when processing cyclic histogram data.