### PR TITLE
XDA-3 Fix page to restore event emails

### DIFF
--- a/Source/Applications/openXDA/openXDA/WebHosting/XDARazorEngine.cs
+++ b/Source/Applications/openXDA/openXDA/WebHosting/XDARazorEngine.cs
@@ -1,0 +1,96 @@
+﻿//******************************************************************************************************
+//  XDARazorEngine.cs - Gbtc
+//
+//  Copyright © 2024, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  01/04/2024 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using GSF.Web.Model;
+using openXDA.Nodes;
+using RazorEngine.Templating;
+
+namespace openXDA.WebHosting
+{
+    public class XDARazorEngine<TLanguage> : IRazorEngine where TLanguage : LanguageConstraint, new()
+    {
+        #region [ Constructors ]
+
+        public XDARazorEngine(Host nodeHost, string templatePath)
+        {
+            NodeHost = nodeHost;
+            GSFRazorEngine = new RazorEngine<TLanguage>(templatePath);
+        }
+
+        #endregion
+
+        #region [ Properties ]
+
+        public string TemplatePath =>
+            GSFRazorEngine.TemplatePath;
+
+        private Host NodeHost { get; }
+        private IRazorEngine GSFRazorEngine { get; }
+        private bool IsDisposed { get; set; }
+
+        #endregion
+
+        #region [ Methods ]
+
+        public void AddTemplate(ITemplateKey key, ITemplateSource templateSource) =>
+            GSFRazorEngine.AddTemplate(key, templateSource);
+
+        public void Compile(ITemplateKey key, Type modelType = null) =>
+            GSFRazorEngine.Compile(key, modelType);
+
+        public ITemplateKey GetKey(string name, ResolveType resolveType = ResolveType.Global, ITemplateKey context = null) =>
+            GSFRazorEngine.GetKey(name, resolveType, context);
+
+        public bool IsTemplateCached(ITemplateKey key, Type modelType) =>
+            GSFRazorEngine.IsTemplateCached(key, modelType);
+
+        public Task PreCompile(Action<Exception> exceptionHandler = null) =>
+            GSFRazorEngine.PreCompile(exceptionHandler);
+
+        public void Run(ITemplateKey key, TextWriter writer, Type modelType = null, object model = null, DynamicViewBag viewBag = null)
+        {
+            viewBag?.AddValue(nameof(NodeHost), NodeHost);
+            GSFRazorEngine.Run(key, writer, modelType, model, viewBag);
+        }
+
+        public void RunCompile(ITemplateKey key, TextWriter writer, Type modelType = null, object model = null, DynamicViewBag viewBag = null)
+        {
+            viewBag?.AddValue(nameof(NodeHost), NodeHost);
+            GSFRazorEngine.RunCompile(key, writer, modelType, model, viewBag);
+        }
+
+        public void Dispose()
+        {
+            if (IsDisposed)
+                return;
+
+            try { GSFRazorEngine.Dispose(); }
+            finally { IsDisposed = true; }
+        }
+
+        #endregion
+    }
+}

--- a/Source/Applications/openXDA/openXDA/WebHosting/XDAWebHost.cs
+++ b/Source/Applications/openXDA/openXDA/WebHosting/XDAWebHost.cs
@@ -112,7 +112,7 @@ namespace openXDA.WebHosting
 
             AppModel = InitializeAppModel();
             AuthenticationOptions = InitializeAuthenticationOptions();
-            WebServer = InitializeWebServer();
+            WebServer = InitializeWebServer(nodeHost);
 
             NodeHost = nodeHost;
             WebApp = Start();
@@ -302,7 +302,7 @@ namespace openXDA.WebHosting
             return webServerOptions;
         }
 
-        private RazorEngine<T> InitializeRazorEngine<T>() where T : LanguageConstraint, new()
+        private IRazorEngine InitializeRazorEngine<TLanguage>(Host nodeHost) where TLanguage : LanguageConstraint, new()
         {
             string templatePath = RetrieveConfigurationFileSetting(
                 name: "TemplatePath",
@@ -310,14 +310,14 @@ namespace openXDA.WebHosting
                 description: "Path for data context based razor field templates.");
 
             string absoluteTemplatePath = FilePath.GetAbsolutePath(templatePath);
-            return new RazorEngine<T>(absoluteTemplatePath);
+            return new XDARazorEngine<TLanguage>(nodeHost, absoluteTemplatePath);
         }
 
-        private WebServer InitializeWebServer()
+        private WebServer InitializeWebServer(Host nodeHost)
         {
             WebServerOptions webServerOptions = InitializeWebServerOptions();
-            IRazorEngine razorEngineCS = InitializeRazorEngine<CSharp>();
-            IRazorEngine razorEngineVB = InitializeRazorEngine<VisualBasic>();
+            IRazorEngine razorEngineCS = InitializeRazorEngine<CSharp>(nodeHost);
+            IRazorEngine razorEngineVB = InitializeRazorEngine<VisualBasic>(nodeHost);
             WebServer webServer = new WebServer(webServerOptions, razorEngineCS, razorEngineVB);
 
             // Attach to default web server events

--- a/Source/Applications/openXDA/openXDA/openXDA.csproj
+++ b/Source/Applications/openXDA/openXDA/openXDA.csproj
@@ -388,6 +388,7 @@
     <Compile Include="WebHosting\HostAuthenticationMiddleware.cs" />
     <Compile Include="WebHosting\UseWhenExtensions.cs" />
     <Compile Include="WebHosting\XDAActionSelector.cs" />
+    <Compile Include="WebHosting\XDARazorEngine.cs" />
     <Compile Include="WebHosting\XDAWebHost.cs" />
     <Compile Include="WebHosting\XDAControllerActivator.cs" />
     <Compile Include="WebHosting\XDAControllerSelector.cs" />

--- a/Source/Applications/openXDA/openXDA/wwwroot/RestoreEventEmail.cshtml
+++ b/Source/Applications/openXDA/openXDA/wwwroot/RestoreEventEmail.cshtml
@@ -21,38 +21,47 @@
 //
 //*******************************************************************************************************@
 
-@using System.Net.Http
 @using GSF.Security
 @using GSF.Web.Model
-@using GSF.Web.Security
-@using openXDA
 @using openXDA.Model
+@using openXDA.Nodes
+@using openXDA.Nodes.Types.Email
 
 @inherits ExtendedTemplateBase<AppModel>
-@{
-    string message = "Access denied.";
 
-    DataContext dataContext = ViewBag.DataContext;
+@{
     Layout = "Layout.cshtml";
     ViewBag.Title = "Restore Event Emails";
 
     SecurityPrincipal principal = ViewBag.SecurityPrincipal;
+    string message = "Access denied.";
+    string detail = "";
 
     if (principal.IsInRole("Administrator"))
     {
-        HttpRequestMessage request = ViewBag.Request;
-        ReadonlyAuthenticationOptions authenticationOptions = ViewBag.AuthenticationOptions;
-        string sessionToken = authenticationOptions.SessionToken;
-        Guid sessionID = SessionHandler.GetSessionIDFromCookie(request, sessionToken);
+        Host nodeHost = ViewBag.NodeHost;
 
-        if (sessionID == Guid.Empty)
+        try
         {
-            sessionID = Guid.NewGuid();
-        }
+            message = "Restoring event emails...";
 
-        ServiceConnection.Default.SendCommand(sessionID.ToString(), principal, "RestoreEventEmails");
-        message = "Event emails have been restored.";
+            detail = EventEmailNode
+                .RestoreEventEmailsAsync(nodeHost)
+                .GetAwaiter()
+                .GetResult();
+        }
+        catch (Exception ex)
+        {
+            message = "Failed to restore event emails";
+            detail = ex.ToString();
+        }
     }
 }
-<br/>
+
+<br />
 <p>@message</p>
+
+@if (!string.IsNullOrEmpty(detail))
+{
+    <pre>@detail</pre>
+}

--- a/Source/Data/05 - DefaultSettings.sql
+++ b/Source/Data/05 - DefaultSettings.sql
@@ -197,6 +197,9 @@ GO
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('EventEmail.MaxEmailSpan', '0.0', '0.0')
 GO
 
+INSERT INTO Setting(Name, Value, DefaultValue) VALUES('EventEmail.RestorationURL', 'http://localhost:8989/RestoreEventEmail.cshtml', 'http://localhost:8989/RestoreEventEmail.cshtml')
+GO
+
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('FaultLocation.MaxFaultDistanceMultiplier', '1.05', '1.05')
 GO
 

--- a/Source/Libraries/openXDA.Configuration/EventEmailSection.cs
+++ b/Source/Libraries/openXDA.Configuration/EventEmailSection.cs
@@ -49,6 +49,10 @@ namespace openXDA.Configuration
             set => MaxEmailSpan = TimeSpan.FromSeconds(value);
         }
 
+        [Setting]
+        [DefaultValue("http://localhost:8989/RestoreEventEmail.cshtml")]
+        public string RestorationURL { get; set; }
+
         public TimeSpan MaxEmailSpan { get; set; }
     }
 }

--- a/Source/Libraries/openXDA.Nodes/Types/Email/EventEmailNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/Email/EventEmailNode.cs
@@ -74,6 +74,9 @@ namespace openXDA.Nodes.Types.Email
             public EventEmailWebController(EventEmailNode node) =>
                 Node = node;
 
+            [HttpGet]
+            public bool IsTripped() => Node.Tripped;
+
             [HttpPost]
             public void TriggerForFileGroup(int fileGroupID, int processingVersion) =>
                 Node.Process(fileGroupID, processingVersion);
@@ -303,16 +306,9 @@ namespace openXDA.Nodes.Types.Email
             string subject = "openXDA email flooding detected";
             StringBuilder message = new StringBuilder();
             List<string> replyTo = new List<string>();
-            string xdaInstance = "http://localhost:8989";
 
             using (AdoDataConnection connection = CreateDbConnection())
             {
-                TableOperations<DashSettings> dashSettingsTable = new TableOperations<DashSettings>(connection);
-                DashSettings xdaInstanceSetting = dashSettingsTable.QueryRecordWhere("Name = 'System.XDAInstance'");
-
-                if ((object)xdaInstanceSetting != null)
-                    xdaInstance = xdaInstanceSetting.Value.TrimEnd('/');
-
                 TableOperations<EmailType> emailTypeTable = new TableOperations<EmailType>(connection);
                 string emailTypeIDs = string.Join(",", m_emailTypes.Select(type => type.EmailTypeID));
                 int eventEmailCategoryID = connection.ExecuteScalar<int>("SELECT ID FROM EmailCategory WHERE Name = 'Event'");
@@ -343,7 +339,7 @@ namespace openXDA.Nodes.Types.Email
             message.AppendLine();
             message.AppendLine($"Event email notifications have been disabled until further notice.");
             message.AppendLine($"Visit the following page to restore event email notifications.");
-            message.AppendLine($"{xdaInstance}/RestoreEventEmail.cshtml");
+            message.AppendLine($"{eventEmailSettings.RestorationURL}");
             message.AppendLine();
             message.AppendLine($"Reply to this message to send a message to all event email subscribers.");
             emailService.SendAdminEmail(subject, message.ToString(), replyTo);

--- a/Source/Libraries/openXDA.Nodes/Types/Email/EventEmailNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/Email/EventEmailNode.cs
@@ -27,8 +27,10 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using FaultData;
@@ -345,6 +347,27 @@ namespace openXDA.Nodes.Types.Email
             message.AppendLine();
             message.AppendLine($"Reply to this message to send a message to all event email subscribers.");
             emailService.SendAdminEmail(subject, message.ToString(), replyTo);
+        }
+
+        #endregion
+
+        #region [ Static ]
+
+        // Static Methods
+        public static async Task<string> RestoreEventEmailsAsync(Host host, CancellationToken cancellationToken = default)
+        {
+            void ConfigureRequest(HttpRequestMessage request)
+            {
+                Type nodeType = typeof(EventEmailNode);
+                string action = nameof(EventEmailWebController.RestoreEventEmails);
+                string url = host.BuildURL(nodeType, action);
+                request.RequestUri = new Uri(url);
+                request.Method = HttpMethod.Post;
+            }
+
+            HttpResponseMessage response = await host.SendWebRequestAsync(ConfigureRequest, cancellationToken);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
         }
 
         #endregion


### PR DESCRIPTION
The custom Razor engine adds a `NodeHost` property to the view bag for Razor views. The view checks permissions and then invokes the new static method in `EventEmailNode`. The static method sends a web request to `/Node/EventEmail/RestoreEventEmails`, which forwards the request along to all instances of `EventEmailNode` in the cluster.