### PR TITLE
Fix errors in database scripts

### DIFF
--- a/Source/Data/01 - openXDA.sql
+++ b/Source/Data/01 - openXDA.sql
@@ -948,7 +948,7 @@ CREATE VIEW StationBattery AS
 		AssetName,
 		AssetTypeID,
 		Spare
-	FROM Asset JOIN StationBatteryAttributes ON Asset.ID = StationBatterAttributes.AssetID
+	FROM Asset JOIN StationBatteryAttributes ON Asset.ID = StationBatteryAttributes.AssetID
 GO
 
 CREATE TRIGGER TR_INSERT_Battery ON STATIONBATTERY

--- a/Source/Data/11 - SEBrowser.sql
+++ b/Source/Data/11 - SEBrowser.sql
@@ -237,7 +237,7 @@ INSERT [SEBrowser.Widget] (Name, Type, Enabled) VALUES ('EventSearchCorrelatedSa
 GO
 INSERT [SEBrowser.Widget] (Name, Type, Enabled) VALUES ('TVASIDA','TVASIDA', 1)
 GO
-INSERT [SEBrowser.Widget] (Name, Type, Enabled) VALUES ('TVASOE', 'TVASOE' 1)
+INSERT [SEBrowser.Widget] (Name, Type, Enabled) VALUES ('TVASOE', 'TVASOE', 1)
 GO
 INSERT [SEBrowser.Widget] (Name, Type, Enabled) VALUES ('TVASLC','TVASLC', 1)
 GO
@@ -247,7 +247,7 @@ INSERT [SEBrowser.Widget] (Name, Type, Enabled) VALUES ('HECCOIR','HECCOIR', 1)
 GO
 INSERT [SEBrowser.Widget] (Name, Type, Enabled) VALUES ('pqi','pqi', 1)
 GO
-INSERT [SEBrowser.Widget] (Name, Type, Enabled) VALUES ('EventSearchFileInfo','EventSearchFileInfo,' 1)
+INSERT [SEBrowser.Widget] (Name, Type, Enabled) VALUES ('EventSearchFileInfo','EventSearchFileInfo', 1)
 GO
 INSERT [SEBrowser.Widget] (Name, Type, Enabled) VALUES ('EventSearchNoteWindow','EventSearchNoteWindow', 1)
 GO


### PR DESCRIPTION
This fixes the errors in openXDA's SQL scripts, shown below.

```
C:\WINDOWS\system32>sqlcmd -S localhost -Q "ALTER DATABASE openXDA SET SINGLE_USER WITH ROLLBACK IMMEDIATE;DROP DATABASE openXDA"

C:\WINDOWS\system32>sqlcmd -S localhost -Q "CREATE DATABASE openXDA"

C:\WINDOWS\system32>sqlcmd -S localhost -d openXDA -i "C:\Projects\openXDA\Source\Data\01 - openXDA.sql"
Msg 4104, Level 16, State 1, Server *****, Procedure StationBattery, Line 13
The multi-part identifier "StationBatterAttributes.AssetID" could not be bound.
Msg 8197, Level 16, State 4, Server *****, Procedure TR_INSERT_Battery, Line 2
The object 'STATIONBATTERY' does not exist or is invalid for this operation.
Msg 8197, Level 16, State 4, Server *****, Procedure TR_UPDATE_Battery, Line 2
The object 'STATIONBATTERY' does not exist or is invalid for this operation.

C:\WINDOWS\system32>sqlcmd -S localhost -d openXDA -i "C:\Projects\openXDA\Source\Data\02 - DashSprocs.sql"
The module 'selectTrendingData' depends on the missing object 'selectTrendingDataByChannelIDDate'. The module will still be created; however, it cannot run successfully until the object exists.

C:\WINDOWS\system32>sqlcmd -S localhost -d openXDA -i "C:\Projects\openXDA\Source\Data\05 - DefaultSettings.sql"

C:\WINDOWS\system32>sqlcmd -S localhost -d openXDA -i "C:\Projects\openXDA\Source\Data\06 - DefaultChannelTypes.sql"

C:\WINDOWS\system32>sqlcmd -S localhost -d openXDA -i "C:\Projects\openXDA\Source\Data\07 - DefaultTrendingAlarms.sql"

C:\WINDOWS\system32>sqlcmd -S localhost -d openXDA -i "C:\Projects\openXDA\Source\Data\08 - DefaultContours.sql"

C:\WINDOWS\system32>sqlcmd -S localhost -d openXDA -i "C:\Projects\openXDA\Source\Data\09 - SystemCenter.sql"

C:\WINDOWS\system32>sqlcmd -S localhost -d openXDA -i "C:\Projects\openXDA\Source\Data\10 - MiMD.sql"

C:\WINDOWS\system32>sqlcmd -S localhost -d openXDA -i "C:\Projects\openXDA\Source\Data\11 - SEBrowser.sql"
Msg 102, Level 15, State 1, Server *****, Line 1
Incorrect syntax near '1'.
Msg 102, Level 15, State 1, Server *****, Line 1
Incorrect syntax near '1'.
Msg 547, Level 16, State 1, Server *****, Line 1
The INSERT statement conflicted with the FOREIGN KEY constraint "FK__SEBrowser__Widge__174363E2". The conflict occurred in database "openXDA", table "dbo.SEBrowser.Widget", column 'ID'.
The statement has been terminated.
Msg 547, Level 16, State 1, Server *****, Line 1
The INSERT statement conflicted with the FOREIGN KEY constraint "FK__SEBrowser__Widge__174363E2". The conflict occurred in database "openXDA", table "dbo.SEBrowser.Widget", column 'ID'.
The statement has been terminated.
```