### PR TITLE
XDA-10 Add FTT option to supply command line arguments to CefSharp

### DIFF
--- a/Source/Libraries/FaultData/DataWriters/GTC/FTTImageGenerator.cs
+++ b/Source/Libraries/FaultData/DataWriters/GTC/FTTImageGenerator.cs
@@ -53,6 +53,7 @@ namespace FaultData.DataWriters.GTC
 
             ImageWidth = options.ImageWidth;
             ImageHeight = options.ImageHeight;
+            BrowserArguments = options.BrowserArguments;
         }
 
         #endregion
@@ -67,6 +68,7 @@ namespace FaultData.DataWriters.GTC
 
         private int ImageWidth { get; }
         private int ImageHeight { get; }
+        private string BrowserArguments { get; }
 
         #endregion
 
@@ -139,7 +141,8 @@ namespace FaultData.DataWriters.GTC
                     ImageWidth.ToString(CultureInfo.InvariantCulture),
                     ImageHeight.ToString(CultureInfo.InvariantCulture),
                     QueryTimeout.TotalSeconds.ToString(CultureInfo.InvariantCulture),
-                    Escape(filePath).QuoteWrap()
+                    Escape(filePath).QuoteWrap(),
+                    BrowserArguments
                 };
 
                 process.StartInfo.FileName = CLIPath;
@@ -239,6 +242,7 @@ namespace FaultData.DataWriters.GTC
             string ignoreCertificateErrors = (string)fttElement.Attribute("ignoreCertificateErrors");
             string fttWidth = (string)fttElement.Attribute("width");
             string fttHeight = (string)fttElement.Attribute("height");
+            string browserArguments = (string)fttElement.Attribute("browserArguments");
 
             if (!int.TryParse(fttWidth, out int imageWidth))
                 throw new FormatException($"FTT width '{fttWidth}' is not an integer.");
@@ -254,6 +258,7 @@ namespace FaultData.DataWriters.GTC
             options.IgnoreCertificateErrors = ignoreCertificateErrors.ParseBoolean();
             options.ImageWidth = imageWidth;
             options.ImageHeight = imageHeight;
+            options.BrowserArguments = browserArguments;
 
             List<FTTRecord> fttRecords = fttElement
                 .Elements("fttRecord")

--- a/Source/Libraries/FaultData/DataWriters/GTC/FTTOptions.cs
+++ b/Source/Libraries/FaultData/DataWriters/GTC/FTTOptions.cs
@@ -35,5 +35,6 @@ namespace FaultData.DataWriters.GTC
 
         public int ImageWidth { get; set; }
         public int ImageHeight { get; set; }
+        public string BrowserArguments { get; set; }
     }
 }

--- a/Source/Tools/FaultTraceToolInterop/Program.cs
+++ b/Source/Tools/FaultTraceToolInterop/Program.cs
@@ -131,6 +131,9 @@ namespace FaultTraceToolInterop
                     IgnoreCertificateErrors = ignoreCertificateErrors
                 };
 
+                foreach (string browserArgument in args.Skip(7))
+                    settings.CefCommandLineArgs.Add(browserArgument);
+
                 Cef.Initialize(settings, performDependencyCheck: true, browserProcessHandler: null);
 
                 using (webView = new ChromiumWebBrowser(builder.ToString()))


### PR DESCRIPTION
Here's a description for how the arguments make their way to CefSharp.

1. User supplies browser arguments to the email template via the `browserArguments` attribute: `<ftt browserArguments="">` 
2. In `ConvertToFTTImageStream()`, read the value from the XML attribute and put it into `FTTOptions`
3. In `FTTImageGenerator` constructor, assign from `FTTOptions.BrowserArguments` to the read-only `BrowserArguments` member
4. In `FTTImageGenerator.Execute()` append the browser arguments to the end of the `fttArguments` array so they will be passed into the `FaultTraceToolInterop` process via `process.StartInfo.Arguments`
5. In `FaultTraceToolInterop`, supply the additional command-line arguments to `CefSettings.CefCommandLineArgs`