### PR TITLE
Fix errors detecting unique constraint violations

### DIFF
--- a/Source/Libraries/FaultData/DataOperations/DFRLineFiles/LineFileLoader.cs
+++ b/Source/Libraries/FaultData/DataOperations/DFRLineFiles/LineFileLoader.cs
@@ -179,11 +179,11 @@ namespace FaultData.DataOperations.DFRLineFiles
                     lineTable.AddNewRecord(line);
                     line.ID = m_connection.ExecuteScalar<int>("SELECT ID FROM Line WHERE AssetKey = {0}", lineID);
                 }
-                catch (SqlException ex)
+                catch (Exception ex)
                 {
                     // Ignore errors regarding unique key constraints
                     // which can occur as a result of a race condition
-                    bool isUniqueViolation = (ex.Number == 2601) || (ex.Number == 2627);
+                    bool isUniqueViolation = ExceptionHandler.IsUniqueViolation(ex);
 
                     if (!isUniqueViolation)
                         throw;
@@ -245,11 +245,11 @@ namespace FaultData.DataOperations.DFRLineFiles
                     TableOperations<AssetConnection> assetConnectionTable = new TableOperations<AssetConnection>(m_connection);
                     assetConnectionTable.AddNewRecord(assetConnection);
                 }
-                catch (SqlException ex)
+                catch (Exception ex)
                 {
                     // Ignore errors regarding unique key constraints
                     // which can occur as a result of a race condition
-                    bool isUniqueViolation = (ex.Number == 2601) || (ex.Number == 2627);
+                    bool isUniqueViolation = ExceptionHandler.IsUniqueViolation(ex);
 
                     if (!isUniqueViolation)
                         throw;
@@ -337,11 +337,11 @@ namespace FaultData.DataOperations.DFRLineFiles
                     measurementTypeTable.AddNewRecord(measurementType);
                     measurementType.ID = m_connection.ExecuteScalar<int>("SELECT ID FROM MeasurementType WHERE Name = {0}", channelInfo.MeasurementType);
                 }
-                catch (SqlException ex)
+                catch (Exception ex)
                 {
                     // Ignore errors regarding unique key constraints
                     // which can occur as a result of a race condition
-                    bool isUniqueViolation = (ex.Number == 2601) || (ex.Number == 2627);
+                    bool isUniqueViolation = ExceptionHandler.IsUniqueViolation(ex);
 
                     if (!isUniqueViolation)
                         throw;
@@ -366,11 +366,11 @@ namespace FaultData.DataOperations.DFRLineFiles
                     measurementCharacteristicTable.AddNewRecord(measurementCharacteristic);
                     measurementCharacteristic.ID = m_connection.ExecuteScalar<int>("SELECT ID FROM MeasurementCharacteristic WHERE Name = 'Instantaneous'");
                 }
-                catch (SqlException ex)
+                catch (Exception ex)
                 {
                     // Ignore errors regarding unique key constraints
                     // which can occur as a result of a race condition
-                    bool isUniqueViolation = (ex.Number == 2601) || (ex.Number == 2627);
+                    bool isUniqueViolation = ExceptionHandler.IsUniqueViolation(ex); ;
 
                     if (!isUniqueViolation)
                         throw;
@@ -395,11 +395,11 @@ namespace FaultData.DataOperations.DFRLineFiles
                     phaseTable.AddNewRecord(phase);
                     phase.ID = m_connection.ExecuteScalar<int>("SELECT ID FROM Phase WHERE Name = {0}", channelInfo.Phase);
                 }
-                catch (SqlException ex)
+                catch (Exception ex)
                 {
                     // Ignore errors regarding unique key constraints
                     // which can occur as a result of a race condition
-                    bool isUniqueViolation = (ex.Number == 2601) || (ex.Number == 2627);
+                    bool isUniqueViolation = ExceptionHandler.IsUniqueViolation(ex);
 
                     if (!isUniqueViolation)
                         throw;
@@ -424,11 +424,11 @@ namespace FaultData.DataOperations.DFRLineFiles
                     seriesTypeTable.AddNewRecord(seriesType);
                     seriesType.ID = m_connection.ExecuteScalar<int>("SELECT ID FROM SeriesType WHERE Name = 'Values'");
                 }
-                catch (SqlException ex)
+                catch (Exception ex)
                 {
                     // Ignore errors regarding unique key constraints
                     // which can occur as a result of a race condition
-                    bool isUniqueViolation = (ex.Number == 2601) || (ex.Number == 2627);
+                    bool isUniqueViolation = ExceptionHandler.IsUniqueViolation(ex);
 
                     if (!isUniqueViolation)
                         throw;
@@ -511,11 +511,11 @@ namespace FaultData.DataOperations.DFRLineFiles
                     measurementTypeTable.AddNewRecord(measurementType);
                     measurementType.ID = m_connection.ExecuteScalar<int>("SELECT ID FROM MeasurementType WHERE Name = 'Digital'");
                 }
-                catch (SqlException ex)
+                catch (Exception ex)
                 {
                     // Ignore errors regarding unique key constraints
                     // which can occur as a result of a race condition
-                    bool isUniqueViolation = (ex.Number == 2601) || (ex.Number == 2627);
+                    bool isUniqueViolation = ExceptionHandler.IsUniqueViolation(ex);
 
                     if (!isUniqueViolation)
                         throw;
@@ -540,11 +540,11 @@ namespace FaultData.DataOperations.DFRLineFiles
                     measurementCharacteristicTable.AddNewRecord(measurementCharacteristic);
                     measurementCharacteristic.ID = m_connection.ExecuteScalar<int>("SELECT ID FROM MeasurementCharacteristic WHERE Name = {0}", digitalInfo.MeasurementCharacteristic);
                 }
-                catch (SqlException ex)
+                catch (Exception ex)
                 {
                     // Ignore errors regarding unique key constraints
                     // which can occur as a result of a race condition
-                    bool isUniqueViolation = (ex.Number == 2601) || (ex.Number == 2627);
+                    bool isUniqueViolation = ExceptionHandler.IsUniqueViolation(ex);
 
                     if (!isUniqueViolation)
                         throw;
@@ -569,11 +569,11 @@ namespace FaultData.DataOperations.DFRLineFiles
                     phaseTable.AddNewRecord(phase);
                     phase.ID = m_connection.ExecuteScalar<int>("SELECT ID FROM Phase WHERE Name = 'None'");
                 }
-                catch (SqlException ex)
+                catch (Exception ex)
                 {
                     // Ignore errors regarding unique key constraints
                     // which can occur as a result of a race condition
-                    bool isUniqueViolation = (ex.Number == 2601) || (ex.Number == 2627);
+                    bool isUniqueViolation = ExceptionHandler.IsUniqueViolation(ex);
 
                     if (!isUniqueViolation)
                         throw;
@@ -598,11 +598,11 @@ namespace FaultData.DataOperations.DFRLineFiles
                     seriesTypeTable.AddNewRecord(seriesType);
                     seriesType.ID = m_connection.ExecuteScalar<int>("SELECT ID FROM SeriesType WHERE Name = 'Values'");
                 }
-                catch (SqlException ex)
+                catch (Exception ex)
                 {
                     // Ignore errors regarding unique key constraints
                     // which can occur as a result of a race condition
-                    bool isUniqueViolation = (ex.Number == 2601) || (ex.Number == 2627);
+                    bool isUniqueViolation = ExceptionHandler.IsUniqueViolation(ex);
 
                     if (!isUniqueViolation)
                         throw;

--- a/Source/Libraries/openXDA.Model/Channels/ChannelData.cs
+++ b/Source/Libraries/openXDA.Model/Channels/ChannelData.cs
@@ -202,11 +202,11 @@ namespace openXDA.Model
                 {
                     channelDataTable.AddNewRecord(channelData);
                 }
-                catch (SqlException ex)
+                catch (Exception ex)
                 {
                     // Ignore errors regarding unique key constraints
                     // which can occur as a result of a race condition
-                    bool isUniqueViolation = (ex.Number == 2601) || (ex.Number == 2627);
+                    bool isUniqueViolation = ExceptionHandler.IsUniqueViolation(ex);
 
                     if (!isUniqueViolation)
                         throw;

--- a/Source/Libraries/openXDA.Model/ExceptionHandler.cs
+++ b/Source/Libraries/openXDA.Model/ExceptionHandler.cs
@@ -22,9 +22,7 @@
 //******************************************************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.Data.SqlClient;
-using System.Linq;
 
 namespace openXDA.Model
 {
@@ -32,17 +30,17 @@ namespace openXDA.Model
     {
         public static bool IsUniqueViolation(Exception ex)
         {
-            if ((object)ex == null)
-                return false;
+            bool IsViolation(int num) => num == 2601 || num == 2627;
 
-            List<Exception> exceptions = new List<Exception>() { ex };
+            while (!(ex is null))
+            {
+                if (ex is SqlException sqlException && IsViolation(sqlException.Number))
+                    return true;
 
-            while ((object)exceptions.Last().InnerException != null)
-                exceptions.Add(ex.InnerException);
-            
-            return exceptions
-                .OfType<SqlException>()
-                .Any(sqlException => (sqlException.Number == 2601) || (sqlException.Number == 2627));
+                ex = ex.InnerException;
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
I noticed the error in `ChannelData` by debugging SE Browser. I went ahead and searched for all usages of `SqlException` so I could fix them. In doing so, I also noticed a bug in the `IsUniqueViolation()` function: `ex.InnerException` was being added to the list multiple times. I decided that simplifying it should help to avoid bugs hiding in the complexities.