### PR TITLE
Optimize performance for queries on alarm tables

### DIFF
--- a/Source/Libraries/openXDA.HIDS/HIDSAlarmOperation.cs
+++ b/Source/Libraries/openXDA.HIDS/HIDSAlarmOperation.cs
@@ -495,6 +495,7 @@ namespace openXDA.HIDS
             {
                 AlarmID = alarm.AlarmID,
                 AlarmFactorID = alarm.AlarmFactorID,
+                SeverityID = alarm.SeverityID,
                 StartTime = range.Start,
                 EndTime = range.End
             }).ToList();

--- a/Source/Libraries/openXDA.Model/ActiveAlarm.cs
+++ b/Source/Libraries/openXDA.Model/ActiveAlarm.cs
@@ -35,6 +35,7 @@ namespace openXDA.Model
         public int AlarmGroupID { get; set; }
         public int AlarmTypeID { get; set; }
         public int? AlarmFactorID { get; set; }
+        public int SeverityID { get; set; }
         public int SeriesID { get; set; }
         public double Value { get; set; }
     }

--- a/Source/Libraries/openXDA.Model/Alarms/AlarmGroups/AlarmLog.cs
+++ b/Source/Libraries/openXDA.Model/Alarms/AlarmGroups/AlarmLog.cs
@@ -37,6 +37,8 @@ namespace openXDA.Model
 
         public int? AlarmFactorID { get; set; }
 
+        public int SeverityID { get; set; }
+
         public DateTime StartTime { get; set; }
 
         public DateTime? EndTime { get; set; }


### PR DESCRIPTION
`LatestAlarmLog` copies all relevant data from the most recent `AlarmLog` record so that `AlarmGroupView` doesn't have to join to the `AlarmLog` table. This should help avoid potential issues with the query optimizer when running queries against `AlarmGroupView`. It also contains a reference to `AlarmLog` just in case. We don't really need it, but it doesn't really cost us anything to capture it on the way by.

`AlarmGroupView` still does `OUTER APPLY` with `TOP 1` because there may still be multiple alarms in an alarm group.