### PR TITLE
Search filters

### DIFF
--- a/Source/Applications/openXDA/openXDA/AppDebug.config
+++ b/Source/Applications/openXDA/openXDA/AppDebug.config
@@ -6,7 +6,7 @@
   <categorizedSettings>
     <systemSettings>
       <!-- *** MODIFY CONNECTION STRING AND DATA PROVIDER STRINGS BELOW *** -->
-      <add name="ConnectionString" value="Data Source=vmhostsql; Initial Catalog=demo_XDA; Integrated Security=SSPI" description="Defines the connection to the openXDA database." encrypted="false" />
+      <add name="ConnectionString" value="Data Source=localhost; Initial Catalog=openXDA; Integrated Security=SSPI" description="Defines the connection to the openXDA database." encrypted="false" />
       <add name="DataProviderString" value="AssemblyName={System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089}; ConnectionType=System.Data.SqlClient.SqlConnection; AdapterType=System.Data.SqlClient.SqlDataAdapter" description="Configuration database ADO.NET data provider assembly type creation string used when ConfigurationType=Database" encrypted="false" />
       <!-- **************************************************************** -->
       <add name="NodeID" value="00000000-0000-0000-0000-000000000000" description="Unique Node ID" encrypted="false" />

--- a/Source/Applications/openXDA/openXDA/AppDebug.config
+++ b/Source/Applications/openXDA/openXDA/AppDebug.config
@@ -6,7 +6,7 @@
   <categorizedSettings>
     <systemSettings>
       <!-- *** MODIFY CONNECTION STRING AND DATA PROVIDER STRINGS BELOW *** -->
-      <add name="ConnectionString" value="Data Source=localhost; Initial Catalog=openXDA; Integrated Security=SSPI" description="Defines the connection to the openXDA database." encrypted="false" />
+      <add name="ConnectionString" value="Data Source=vmhostsql; Initial Catalog=demo_XDA; Integrated Security=SSPI" description="Defines the connection to the openXDA database." encrypted="false" />
       <add name="DataProviderString" value="AssemblyName={System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089}; ConnectionType=System.Data.SqlClient.SqlConnection; AdapterType=System.Data.SqlClient.SqlDataAdapter" description="Configuration database ADO.NET data provider assembly type creation string used when ConfigurationType=Database" encrypted="false" />
       <!-- **************************************************************** -->
       <add name="NodeID" value="00000000-0000-0000-0000-000000000000" description="Unique Node ID" encrypted="false" />

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/AlarmTypeSlice.ts
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/AlarmTypeSlice.ts
@@ -84,9 +84,9 @@ function GetAlarmTypes(): JQuery.jqXHR<string> {
     // not really an int but this avoids some of the replacment going on server side
     let filter = [{
         FieldName: "Name",
-        SearchText: "('Upper Limit','Lower Limit')",
+        SearchText: "Upper Limit,Lower Limit",
         Operator: "IN",
-        Type: "integer"
+        Type: "string"
     }];
 
     return $.ajax({

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/SeriesTypeSlice.ts
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/SeriesTypeSlice.ts
@@ -85,9 +85,9 @@ function GetSeriesType(): JQuery.jqXHR<string> {
     // not really an int but this avoids some of the replacment going on server side
     let filter = [{
         FieldName: "Name",
-        SearchText: "('Minimum','Maximum','Average')",
+        SearchText: "Minimum,Maximum,Average",
         Operator: "IN",
-        Type: "integer"
+        Type: "string"
     }];
 
     return $.ajax({

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/WizardAffectedChannelSlice.ts
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/WizardAffectedChannelSlice.ts
@@ -105,7 +105,7 @@ function GetAffectedChannels(meterIDs: number[], measurementTypeID: number, seri
     let filter = [
         {
             FieldName: "MeterID",
-            SearchText: `(${(meterIDs.length > 0 ? meterIDs.join(',') : 0)})`,
+            SearchText: `${(meterIDs.length > 0 ? meterIDs.join(',') : 0)}`,
             Operator: "IN",
             Type: "integer"
         },
@@ -113,13 +113,13 @@ function GetAffectedChannels(meterIDs: number[], measurementTypeID: number, seri
             FieldName: "MeasurementType",
             SearchText: `${measurementTypeID}`,
             Operator: "=",
-            Type: "integer"
+            Type: "query"
         },
          {
             FieldName: "MeasurementCharacteristic",
             SearchText: `${measurementTypeID}`,
             Operator: "=",
-            Type: "integer"
+            Type: "query"
         },
         {
             FieldName: `SeriesID`,
@@ -129,7 +129,7 @@ function GetAffectedChannels(meterIDs: number[], measurementTypeID: number, seri
         },
         {
             FieldName: "PhaseID",
-            SearchText: `(${(phaseIDs.length > 0 ? phaseIDs.join(',') : 0)})`,
+            SearchText: `${(phaseIDs.length > 0 ? phaseIDs.join(',') : 0)}`,
             Operator: "IN",
             Type: "integer"
         },

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/WizardAffectedChannelSlice.ts
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/WizardAffectedChannelSlice.ts
@@ -110,22 +110,22 @@ function GetAffectedChannels(meterIDs: number[], measurementTypeID: number, seri
             Type: "integer"
         },
         {
-            FieldName: "MeasurementTypeID",
-            SearchText: `(SELECT ChannelGroupType.MeasurementTypeID FROM ChannelGroupType WHERE ID = ${measurementTypeID})`,
+            FieldName: "MeasurementType",
+            SearchText: `${measurementTypeID}`,
+            Operator: "=",
+            Type: "integer"
+        },
+         {
+            FieldName: "MeasurementCharacteristic",
+            SearchText: `${measurementTypeID}`,
             Operator: "=",
             Type: "integer"
         },
         {
-            FieldName: "MeasurementCharacteristicID",
-            SearchText: `(SELECT ChannelGroupType.MeasurementCharacteristicID FROM ChannelGroupType WHERE ID = ${measurementTypeID})`,
-            Operator: "=",
-            Type: "integer"
-        },
-        {
-            FieldName: `(SELECT COUNT(Series.ID) FROM SERIES WHERE Series.ChannelID = FullTbl.ID AND Series.SeriesTypeID = ${seriesTypeID})`,
-            SearchText: "0",
+            FieldName: `SeriesID`,
+            SearchText: `${seriesTypeID}`,
             Operator: ">",
-            Type: "query"
+            Type: "integer"
         },
         {
             FieldName: "PhaseID",
@@ -134,11 +134,11 @@ function GetAffectedChannels(meterIDs: number[], measurementTypeID: number, seri
             Type: "integer"
         },
         {
-            FieldName: "(SELECT VoltageKV FROM Asset WHERE Asset.ID = FullTbl.AssetID)",
-            SearchText: `(${(voltages.length > 0 ? voltages.join(',') : 0)})`,
+            FieldName: "VoltageKV",
+            SearchText: `${(voltages.length > 0 ? voltages.join(',') : 0)}`,
             Operator: "IN",
-            Type: "query"
-        }
+            Type: "integer"
+        },
     ];
 
     return $.ajax({

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/WizardAffectedChannelSlice.ts
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/WizardAffectedChannelSlice.ts
@@ -113,13 +113,13 @@ function GetAffectedChannels(meterIDs: number[], measurementTypeID: number, seri
             FieldName: "MeasurementType",
             SearchText: `${measurementTypeID}`,
             Operator: "=",
-            Type: "query"
+            Type: "integer"
         },
          {
             FieldName: "MeasurementCharacteristic",
             SearchText: `${measurementTypeID}`,
             Operator: "=",
-            Type: "query"
+            Type: "integer"
         },
         {
             FieldName: `SeriesID`,

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/WizardPhaseOptionSlice.ts
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/WizardPhaseOptionSlice.ts
@@ -126,7 +126,7 @@ function getAvailablePhases(meterIDs: number[], measurementTypeID: number, serie
         FieldName: "ID",
         SearchText: `(${sqlFilter})`,
         Operator: "IN",
-        Type: "integer"
+        Type: "query"
     }];
 
     return $.ajax({

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/WizardVoltageOptionSlice.ts
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/WizardVoltageOptionSlice.ts
@@ -127,7 +127,7 @@ function getAvailableVoltages(meterIDs: number[], measurementTypeID: number, ser
         FieldName: "ID",
         SearchText: `(${sqlFilter})`,
         Operator: "IN",
-        Type: "integer"
+        Type: "query"
     }];
 
     return $.ajax({

--- a/Source/Data/05 - DefaultSettings.sql
+++ b/Source/Data/05 - DefaultSettings.sql
@@ -780,37 +780,37 @@ GO
 -- Standard MagDur Curves --
 INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'ITIC', NULL, '#007a29')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'SEMI F47',1, 0.05, 1,0, NULL, '#edc240')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'SEMI F47', NULL, '#edc240')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1668 Type I & II', 3,0.01, 1.2,0, NULL, '#a30000')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1668 Type I & II', NULL, '#a30000')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1668 Type III', 3,0.01, 1.2,0, NULL, '#185aa9')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1668 Type III', NULL, '#185aa9')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'NERC PRC-024-2', 4,0.001,1.3,0, NULL, '#d3d3d3')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'NERC PRC-024-2', NULL, '#d3d3d3')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Transients', 0,0, 0,0, NULL, '#afd8f8')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Transients', NULL, '#afd8f8')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Instantaneous Sag', 0,0, 0,0, NULL, '#f47d23')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Instantaneous Sag', NULL, '#f47d23')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Instantaneous Swell', 0,0, 0,0, NULL, '#008c48')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Instantaneous Swell', NULL, '#008c48')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Mom. Interruption', 0,0, 0,0, NULL, '#ee2e2f')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Mom. Interruption', NULL, '#ee2e2f')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Momentary Sag', 0,0, 0,0, NULL, '#737373')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Momentary Sag', NULL, '#737373')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Momentary Swell', 0,0, 0,0, NULL, '#662c91')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Momentary Swell', NULL, '#662c91')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Temp. Interruption', 0,0, 0,0, NULL, '#bd9b33')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Temp. Interruption', NULL, '#bd9b33')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Temporary Sag', 0,0, 0,0, NULL,'#ff904f')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Temporary Sag', NULL,'#ff904f')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Temporary Swell', 0,0, 0,0, NULL, '#ff9999')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Temporary Swell', NULL, '#ff9999')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Sustained Int.', 0,0, 0,0, NULL, '#0029A3')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Sustained Int.', NULL, '#0029A3')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Undervoltage', 0,0, 0,0, NULL, '#cb4b4b')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Undervoltage', NULL, '#cb4b4b')
 GO
-INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Overvoltage', 0,0, 0,0, NULL, '#4da74d')
+INSERT StandardMagDurCurve (Name, Area, Color) VALUES (N'IEEE 1159 Overvoltage', NULL, '#4da74d')
 GO
 
 UPDATE StandardMagDurCurve SET Area = 'POLYGON((0.01 0.5, 0.2 0.5, 0.2 0.7, 0.5 0.7,0.5 0.8,2 0.8,2 1.0,0.01 1.0, 0.01 0.5))' WHERE Name = 'IEEE 1668 Type I & II'

--- a/Source/Libraries/openXDA.Model/Channels/Channel.cs
+++ b/Source/Libraries/openXDA.Model/Channels/Channel.cs
@@ -512,13 +512,13 @@ namespace openXDA.Model
                 sql = " (SELECT VoltageKV FROM Asset WHERE Asset.ID = FullTbl.AssetID) " + filter.Operator + " " + GenerateQueryParams();
 
             if (filter.FieldName == "MeasurementCharacteristic")
-                sql = "MeasurementCharacteristicID = (SELECT ChannelGroupType.MeasurementCharacteristicID FROM ChannelGroupType WHERE ID " + filter.Operator + " " + GenerateQueryParams() + " )";
+                sql = "MeasurementCharacteristicID = (SELECT ChannelGroupType.MeasurementCharacteristicID FROM ChannelGroupType WHERE ID " + filter.Operator + GenerateQueryParams() + " )";
 
             if (filter.FieldName == "SeriesID")
                 sql = "(SELECT COUNT(Series.ID) FROM SERIES WHERE Series.ChannelID = FullTbl.ID AND Series.SeriesTypeID " + filter.Operator + GenerateQueryParams() + " ) > 0";
 
             if (filter.FieldName == "MeasurementType")
-                sql = "MeasurementTypeID = (SELECT ChannelGroupType.MeasurementTypeID FROM ChannelGroupType WHERE ID " + filter.Operator + " " + GenerateQueryParams() + " )";
+                sql = "MeasurementTypeID = (SELECT ChannelGroupType.MeasurementTypeID FROM ChannelGroupType WHERE ID " + filter.Operator + GenerateQueryParams() + " )";
 
             if (sql != "")
                 return sql;

--- a/Source/Libraries/openXDA.Model/Channels/Channel.cs
+++ b/Source/Libraries/openXDA.Model/Channels/Channel.cs
@@ -501,6 +501,50 @@ namespace openXDA.Model
         public int SeriesTypeID { get; set; }
 
         public string SeriesType { get; set; }
+        
+        [SQLSearchModifier]
+        public static string SearchModifier(SQLSearchFilter filter, List<object> param)
+        {
+           
+            string sql = "";
+
+            if(filter.FieldName == "VoltageKV")
+                sql = " (SELECT VoltageKV FROM Asset WHERE Asset.ID = FullTbl.AssetID) " + filter.Operator + " " + GenerateQueryParams();
+
+            if (filter.FieldName == "MeasurementCharacteristic")
+                sql = "MeasurementCharacteristicID = (SELECT ChannelGroupType.MeasurementCharacteristicID FROM ChannelGroupType WHERE ID " + filter.Operator + " " + GenerateQueryParams() + " )";
+
+            if (filter.FieldName == "SeriesID")
+                sql = "(SELECT COUNT(Series.ID) FROM SERIES WHERE Series.ChannelID = FullTbl.ID AND Series.SeriesTypeID " + filter.Operator + GenerateQueryParams() + " ) > 0";
+
+            if (filter.FieldName == "MeasurementType")
+                sql = "MeasurementTypeID = (SELECT ChannelGroupType.MeasurementTypeID FROM ChannelGroupType WHERE ID " + filter.Operator + " " + GenerateQueryParams() + " )";
+
+            if (sql != "")
+                return sql;
+
+            return filter.GenerateConditional(param); //base case
+
+            string GenerateQueryParams()
+            {
+                string queryParam;
+                if (string.Equals(filter.Operator, "IN", StringComparison.OrdinalIgnoreCase) || string.Equals(filter.Operator, "NOT IN", StringComparison.OrdinalIgnoreCase))
+                {
+                    IEnumerable<string> values = from t in filter.SearchText.Replace("(", "").Replace(")", "").Split(',')
+                                                 select "" + t + "";
+                    filter.SearchText = "(" + string.Join(",", values) + ")";
+                    queryParam = " " + filter.SearchText;
+                }
+                else
+                {
+                    queryParam = $" {{{param.Count}}}";
+                    param.Add(filter.SearchText);
+                }
+                return queryParam;
+            }
+
+        }
+        
     }
 
     public class ChannelInfo

--- a/Source/Libraries/openXDA.Model/TransmissionElements/StandardMagDurCurve.cs
+++ b/Source/Libraries/openXDA.Model/TransmissionElements/StandardMagDurCurve.cs
@@ -28,7 +28,7 @@ using GSF.Data.Model;
 namespace openXDA.Model
 {
     [CustomView(@"SELECT
-                    ID, Name, XHigh, XLow, YHigh, YLow, Color, NULL AS UpperCurve, NULL AS LowerCurve,
+                    ID, Name, Color,
                     REPLACE(REPLACE(RIGHT(Area.STAsText(), len(Area.STAsText()) - charindex('(', Area.STAsText())),')',''),'(','') AS Area
                     FROM StandardMagDurCurve")]
     [AllowSearch]


### PR DESCRIPTION
Fix 500 errors coming from the calls to `SearchableList`. 
Added a SQLSearchModifer function to the `ChannelDetail` ModelController for the filters that were using the `query` type. 
This PR is dependent on https://github.com/GridProtectionAlliance/gsf/pull/239 being approved/merged. Along with a GSF.Web update on the openXDA side. 