### PR TITLE
Add 'Select All' option to Wizard channel selection

### DIFF
--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/GeneralSettings.tsx
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/GeneralSettings.tsx
@@ -215,12 +215,12 @@ const AddMeterPopUp = (props: { setter: (meters: Array<openXDA.IMeter>) => void 
                         </SearchBar>
                         <SelectTable<openXDA.IMeter>
                             cols={[
-                                { key: 'Name', label: 'Name', field: 'Name', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
-                                { key: 'Location', label: 'Substation', field: 'Location', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
-                                { key: 'Make', label: 'Make', field: 'Make', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
-                                { key: 'Model', label: 'Model', field: 'Model', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
+                                { key: 'Name', label: 'Name', field: 'Name', headerStyle: { width: 'auto' }, rowStyle: { verticalAlign: 'middle', width: 'auto' } },
+                                { key: 'Location', label: 'Substation', field: 'Location', headerStyle: { width: 'auto' }, rowStyle: { verticalAlign: 'middle', width: 'auto' } },
+                                { key: 'Make', label: 'Make', field: 'Make', headerStyle: { width: 'auto' }, rowStyle: { verticalAlign: 'middle', width: 'auto' } },
+                                { key: 'Model', label: 'Model', field: 'Model', headerStyle: { width: 'auto' }, rowStyle: { verticalAlign: 'middle', width: 'auto' } },
                             ]}
-                            tableClass="table table-hover"
+                            tableClass="table table-hover table-sm"
                             data={meterList}
                             sortKey={sort}
                             ascending={asc}

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/SelectStatisticsData.tsx
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/SelectStatisticsData.tsx
@@ -257,16 +257,21 @@ const ChannelTable = () => {
     const sort = useSelector(SelectAffectedChannelSortField);
     const asc = useSelector(SelectAffectedChannelAscending);
 
+    const [selectAllCounter, setSelectAllCounter] = React.useState(0);
+    const [allSelected, setAllSelected] = React.useState(false);
+    const selectAllText = React.useMemo(() => allSelected ? "Deselect All" : "Select All", [allSelected]);
+
     return (
         <div style={{ width: '100%', height: '100%' }}>
+            <a href="#" className="link-primary" onClick={() => setSelectAllCounter(selectAllCounter + 1)}>{selectAllText}</a>
             <SelectTable<openXDA.IChannel>
                 cols={[
-                    { key: 'MeterName', label: 'Meter', field: 'MeterName', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
-                    { key: 'AssetKey', label: 'Asset', field: 'AssetKey', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
-                    { key: 'Name', label: 'Channel', field: 'Name', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
-                    { key: 'Phase', label: 'Phase', field: 'Phase', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
+                    { key: 'MeterName', label: 'Meter', field: 'MeterName', headerStyle: { width: 'auto' }, rowStyle: { verticalAlign: 'middle', width: 'auto' } },
+                    { key: 'AssetKey', label: 'Asset', field: 'AssetKey', headerStyle: { width: 'auto' }, rowStyle: { verticalAlign: 'middle', width: 'auto' } },
+                    { key: 'Name', label: 'Channel', field: 'Name', headerStyle: { width: 'auto' }, rowStyle: { verticalAlign: 'middle', width: 'auto' } },
+                    { key: 'Phase', label: 'Phase', field: 'Phase', headerStyle: { width: 'auto' }, rowStyle: { verticalAlign: 'middle', width: 'auto' } },
                 ]}
-                tableClass="table table-hover"
+                tableClass="table table-hover table-sm"
                 data={channelList}
                 sortKey={sort}
                 ascending={asc}
@@ -274,7 +279,8 @@ const ChannelTable = () => {
                 tbodyStyle={{ display: 'block', overflowY: 'scroll', maxHeight: 400, width: '100%' }}
                 rowStyle={{ fontSize: 'smaller', display: 'table', tableLayout: 'fixed', width: '100%' }}
                 KeyField={'ID'}
-                onSelection={(selected) => { dispatch(updateStatisticChannels(selected)); }}
+                onSelection={(selected) => { setAllSelected(selected.length === channelList.length); dispatch(updateStatisticChannels(selected)); }}
+                selectAllCounter={selectAllCounter}
             />
         </div>
     )


### PR DESCRIPTION
It seems the setpoint expression page forces you to define a static, scalar-valued expression if you don't select all channels as a historical basis for the alarm. This means you cannot, for example, define an alarm with the expression `Vbase*1.05` unless you are able to select all channels in the previous step. However, when you are creating an alarm group for 5000 different channels, you'd have to scroll through the list and click all 5000 channels individually. This page desperately needs a "Select All" button.

I also tweaked some of the styles and submitted two PRs to gpa-gemstone that should help clean things up further.
https://github.com/GridProtectionAlliance/gpa-gemstone/pull/245
https://github.com/GridProtectionAlliance/gpa-gemstone/pull/246

XDA-13