### PR TITLE
SPC Tools resolve performance issues on WizardTest page

### DIFF
--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/AlarmTrendingCard.tsx
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/AlarmTrendingCard.tsx
@@ -286,7 +286,10 @@ export const AlarmTrendingCard = (props: IProps) => {
                 <div className="col-12" ref={divref}>
                     {loading ?
                         <LoadingIcon Show={true} Size={40} /> : 
-                        <Plot height={250} width={Width} defaultTdomain={[Tstart, Tend]} Tlabel={'Time'} zoom={true} showMouse={false} useMetricFactors={false}>
+                        <Plot height={250} width={Width}
+                            yDomain={'AutoValue'}
+                            defaultTdomain={[Tstart, Tend]}
+                             Tlabel={'Time'} zoom={true} showMouse={false} useMetricFactors={false} >
                             {(data.length > 0 && data[0].data.length > 0) ? data.map((series, i) => <Line key={i} data={series.data} color={series.color} lineStyle={series.lineStyle} />)
                             : <></>
                             }

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/AlarmTrendingCard.tsx
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/AlarmTrendingCard.tsx
@@ -287,9 +287,10 @@ export const AlarmTrendingCard = (props: IProps) => {
                     {loading ?
                         <LoadingIcon Show={true} Size={40} /> : 
                         <Plot height={250} width={Width}
+                            zoom={false}
                             yDomain={'AutoValue'}
                             defaultTdomain={[Tstart, Tend]}
-                             Tlabel={'Time'} zoom={true} showMouse={false} useMetricFactors={false} >
+                             Tlabel={'Time'}showMouse={false} useMetricFactors={false} >
                             {(data.length > 0 && data[0].data.length > 0) ? data.map((series, i) => <Line key={i} data={series.data} color={series.color} lineStyle={series.lineStyle} />)
                             : <></>
                             }

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/SelectStatisticsData.tsx
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/SelectStatisticsData.tsx
@@ -23,12 +23,13 @@
 
 import * as React from 'react';
 import { SPCTools, openXDA } from '../global';
-import { DateRangePicker, CheckBox, Input } from '@gpa-gemstone/react-forms';
+import { DateRangePicker, CheckBox, Input, DatePicker } from '@gpa-gemstone/react-forms';
 import { useSelector, useDispatch } from 'react-redux';
 import _ from 'lodash';
 import { SelectStatisticsrange, updateStatisticsRange, updateStatisticsFilter, updateStatisticChannels, SelectStatisticsFilter } from './DynamicWizzardSlice';
 import { SelectAffectedChannelSortField, SelectAffectedChannelAscending, SelectAffectedChannels } from '../store/WizardAffectedChannelSlice';
 import { SelectTable } from '@gpa-gemstone/react-table';
+import moment from 'moment';
 
 declare var homePath: string;
 declare var apiHomePath: string;
@@ -51,10 +52,10 @@ const SelectStatisticsData = (props: IProps) => {
     const [range, setRange] = React.useState<Duration>('Custom');
     
     React.useEffect(() => {
-        if (range === 'custom')
+        if (range === 'Custom')
             return;
-        const toTime: moment.Moment =  moment(dateRange.start, "YYYY-MM-DD").add(GetDays(range), 'days');
-        dispatch(updateStatisticsRange({...dateRange, end: toTime}))
+        const toTime: moment.Moment = moment(dateRange.start, "YYYY-MM-DD").add(GetDays(range), 'days');
+        dispatch(updateStatisticsRange({ ...dateRange, end: toTime.format("YYYY-MM-DD") }))
     }, [range]);
 
     function GetDays(val: Duration) {
@@ -81,9 +82,10 @@ const SelectStatisticsData = (props: IProps) => {
                 </div>
             </div>
             <div className="row" style={{ margin: 0 }}>
-                <div className="col-6">
+                <div className="col-12">
                     <div className="row">
-                        <div className="col">
+                        <div className="col-3">
+                            <label>Duration:</label>
                             <select className="form-control" value={range} onChange={(evt) => setRange(evt.target.value as Duration)}>
                                 <option value="Custom">Custom</option>
                                 <option value="1 Day">1 Day</option>
@@ -94,14 +96,14 @@ const SelectStatisticsData = (props: IProps) => {
                                 <option value="365 Days">365 Days</option>
                             </select>
                         </div>
-                        <div className="col">
+                        <div className="col-3">
                             <DatePicker<SPCTools.IDateRange> Record={dateRange}
                                 Field="start"
                                 Setter={(r) => { 
-                                    if (range === 'custom')
+                                    if (range === 'Custom')
                                         return;
                                     const toTime: moment.Moment =  moment(r.start, "YYYY-MM-DD").add(GetDays(range), 'days');
-                                    dispatch(updateStatisticsRange({...r, end: toTime}))
+                                    dispatch(updateStatisticsRange({...r, end: toTime.format("YYYY-MM-DD")}))
                                 }}
                                 Label='From:'
                                 Type='date'
@@ -109,12 +111,12 @@ const SelectStatisticsData = (props: IProps) => {
                                 Format={"YYYY-MM-DD"}
                             />
                         </div> 
-                        <div className="col">
+                        <div className="col-3">
                         <DatePicker<SPCTools.IDateRange> Record={dateRange}
                                 Field="end"
                                 Setter={(r) => {
                                     dispatch(updateStatisticsRange(r))
-                                    setRange('custom');
+                                    setRange('Custom');
                                 }}
                                 Label='To:'
                                 Type='date'

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/SelectStatisticsData.tsx
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/SelectStatisticsData.tsx
@@ -101,9 +101,11 @@ const SelectStatisticsData = (props: IProps) => {
                                 Field="start"
                                 Setter={(r) => { 
                                     if (range === 'Custom')
-                                        return;
-                                    const toTime: moment.Moment =  moment(r.start, "YYYY-MM-DD").add(GetDays(range), 'days');
-                                    dispatch(updateStatisticsRange({...r, end: toTime.format("YYYY-MM-DD")}))
+                                        dispatch(updateStatisticsRange(r));
+                                    else {
+                                        const toTime: moment.Moment = moment(r.start, "YYYY-MM-DD").add(GetDays(range), 'days');
+                                        dispatch(updateStatisticsRange({ ...r, end: toTime.format("YYYY-MM-DD") }))
+                                    }
                                 }}
                                 Label='From:'
                                 Type='date'
@@ -115,8 +117,12 @@ const SelectStatisticsData = (props: IProps) => {
                         <DatePicker<SPCTools.IDateRange> Record={dateRange}
                                 Field="end"
                                 Setter={(r) => {
-                                    dispatch(updateStatisticsRange(r))
-                                    setRange('Custom');
+                                    if (range === 'Custom')
+                                        dispatch(updateStatisticsRange(r));
+                                    else {
+                                        const fromTime: moment.Moment = moment(r.end, "YYYY-MM-DD").subtract(GetDays(range), 'days');
+                                        dispatch(updateStatisticsRange({ ...r, start: fromTime.format("YYYY-MM-DD") }))
+                                    }
                                 }}
                                 Label='To:'
                                 Type='date'

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/SelectStatisticsData.tsx
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/SelectStatisticsData.tsx
@@ -40,12 +40,38 @@ interface IProps { }
 //Todo
 // # Removed Meter table for now due to EPRI Time contraints
 
+type Duration = ('Custom' | '1 Day' | '7 Days' | '30 Days' | '90 Days' | '180 Days' | '365 Days')
+
 const SelectStatisticsData = (props: IProps) => {
     const dispatch = useDispatch();
 
     const dateRange = useSelector(SelectStatisticsrange)
     const dataFilter = useSelector(SelectStatisticsFilter)
 
+    const [range, setRange] = React.useState<Duration>('Custom');
+    
+    React.useEffect(() => {
+        if (range === 'custom')
+            return;
+        const toTime: moment.Moment =  moment(dateRange.start, "YYYY-MM-DD").add(GetDays(range), 'days');
+        dispatch(updateStatisticsRange({...dateRange, end: toTime}))
+    }, [range]);
+
+    function GetDays(val: Duration) {
+        if (val === '1 Day')
+          return 1;
+        if (val === '7 Days')
+          return 7;
+        if (val === '30 Days')
+          return 30;
+        if (val === '90 Days')
+          return 90;
+        if (val === '180 Days')
+          return 180;
+        if (val === '365 Days')
+          return 365;
+        return 0;
+      }
 
     return (
         <div style={{ width: '100%', height: '100%' }}>
@@ -56,7 +82,47 @@ const SelectStatisticsData = (props: IProps) => {
             </div>
             <div className="row" style={{ margin: 0 }}>
                 <div className="col-6">
-                    <DateRangePicker<SPCTools.IDateRange> Label={''} Record={dateRange} FromField={'start'} ToField={'end'} Setter={(r) => dispatch(updateStatisticsRange(r))} Valid={() => true} />
+                    <div className="row">
+                        <div className="col">
+                            <select className="form-control" value={range} onChange={(evt) => setRange(evt.target.value as Duration)}>
+                                <option value="Custom">Custom</option>
+                                <option value="1 Day">1 Day</option>
+                                <option value="7 Days">7 Days</option>
+                                <option value="30 Days">30 Days</option>
+                                <option value="90 Days">90 Days</option>
+                                <option value="180 Days">180 Days</option>
+                                <option value="365 Days">365 Days</option>
+                            </select>
+                        </div>
+                        <div className="col">
+                            <DatePicker<SPCTools.IDateRange> Record={dateRange}
+                                Field="start"
+                                Setter={(r) => { 
+                                    if (range === 'custom')
+                                        return;
+                                    const toTime: moment.Moment =  moment(r.start, "YYYY-MM-DD").add(GetDays(range), 'days');
+                                    dispatch(updateStatisticsRange({...r, end: toTime}))
+                                }}
+                                Label='From:'
+                                Type='date'
+                                Valid={() => true} 
+                                Format={"YYYY-MM-DD"}
+                            />
+                        </div> 
+                        <div className="col">
+                        <DatePicker<SPCTools.IDateRange> Record={dateRange}
+                                Field="end"
+                                Setter={(r) => {
+                                    dispatch(updateStatisticsRange(r))
+                                    setRange('custom');
+                                }}
+                                Label='To:'
+                                Type='date'
+                                Valid={() => true} 
+                                Format={"YYYY-MM-DD"}
+                            />
+                        </div>
+                    </div>
                 </div>
             </div>
             <div className="row" style={{ margin: 0 }}>

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/WizardTest.tsx
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/WizardTest.tsx
@@ -65,16 +65,11 @@ const WizardTest = (props: IProps) => {
     const statTimeRange = useSelector(SelectStatisticsrange);
     const alarmVaues = useSelector(SelectAllAlarmValues);
 
-    //const testResult = useSelector(selectResultSummary)
-
     const [sort, setSort] = React.useState<keyof IChannelList>('NumberRaised')
     const [asc, setAsc] = React.useState<boolean>(false)
 
     const alarmFactors = useSelector(SelectAlarmFactors);
-    //const severityID = useSelector(selectSeverity);
     const severities = useSelector(SelectSeverities)
-
-    
 
     // Plot Data is Local since it is not used anywhere else
     const [selectedChannel, setSelectedChannel] = React.useState<number>(-1);
@@ -89,11 +84,6 @@ const WizardTest = (props: IProps) => {
     React.useEffect(() => {
         UpdateChannelTable();
     }, [selectedChannel]);
-
-    // To Load Something on Initialization
-    React.useEffect(() => {
-        handle.current = LoadTest();
-    }, []);
 
     function LoadTest(): JQuery.jqXHR {
 

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/WizardTest.tsx
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/WizardTest.tsx
@@ -200,7 +200,7 @@ const WizardTest = (props: IProps) => {
 
     let validStartDate = !isNaN(new Date(timeRange.start).getTime()) && timeRange.start != null;
     let validEndDate = !isNaN(new Date(timeRange.end).getTime()) && timeRange.end != null &&
-        (new Date(timeRange.end).getDate() > new Date(timeRange.start).getDate() || !validStartDate)
+        (new Date(timeRange.end) > new Date(timeRange.start) || !validStartDate)
 
     return (
         <div style={{ width: '100%', height: '100%' }}>

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/WizardTest.tsx
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/WizardTest.tsx
@@ -89,11 +89,11 @@ const WizardTest = (props: IProps) => {
 
     React.useEffect(() => {
         if (userConfirm == 'confirm') {
-            const nChannels = channelList.length;
+            const nChannels = statChannels.length;
             const nDays = (Date.parse(timeRange.end) - Date.parse(timeRange.start)) / (1000.0 * 60.0 * 60.0 * 24.0);
 
             // Adjust statement below - if true it will not show the warning (e.g. for small datasets)
-            if (nDays * nChannels < 2)
+            if (nDays * nChannels < 14)
                 setUserConfirm('loading');
         }
         if (userConfirm == 'loading') {

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/WizardTest.tsx
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/Wizard/WizardTest.tsx
@@ -27,9 +27,9 @@ import Table from '@gpa-gemstone/react-table';
 import { DateRangePicker } from '@gpa-gemstone/react-forms';
 import { useSelector, useDispatch } from 'react-redux';
 import _, { cloneDeep } from 'lodash';
-import { 
+import {
     selectAlarmGroup, selectSeriesTypeID, SelectAlarmFactors,
-    SelectStatisticsFilter, SelectStatisticsChannels, SelectStatisticsrange, 
+    SelectStatisticsFilter, SelectStatisticsChannels, SelectStatisticsrange,
     SelectAllAlarmValues } from './DynamicWizzardSlice';
 import { SelectAffectedChannels } from '../store/WizardAffectedChannelSlice';
 import { SelectSeverities } from '../store/SeveritySlice';
@@ -45,7 +45,7 @@ interface IProps { }
 interface IResultTable { Severity: string, Threshhold: number, NumberRaised: number, TimeInAlarm: number}
 interface IChannelList { MeterName: string, Name: string, NumberRaised: number, TimeInAlarm: number, ID: number }
 
-type preLoadState = 'uninitialized'|'confirm'|'loading'
+type preLoadState = 'uninitialized' | 'confirm' | 'loading';
 
 const defaultTimeRange = {
     start: `${(new Date()).getFullYear()}-${((new Date()).getMonth()).toString().padStart(2, '0')}-${(new Date()).getDate().toString().padStart(2, '0')}`,
@@ -85,22 +85,22 @@ const WizardTest = (props: IProps) => {
     const [channelList, setChannelList] = React.useState<IChannelList[]>([])
 
     // Logic for large DatasetWarning
-    const [userConfirm, setUserConfirm] = React.useState<preLoadState>('uninitialized')
+    const [userConfirm, setUserConfirm] = React.useState<preLoadState>('uninitialized');
 
     React.useEffect(() => {
         if (userConfirm == 'confirm') {
             const nChannels = channelList.length;
-            const nDays = (Date.parse(timeRange.end) - Date.parse(timeRange.start)) / (1000.0 * 60.0 * 60.0 * 24.0);    
+            const nDays = (Date.parse(timeRange.end) - Date.parse(timeRange.start)) / (1000.0 * 60.0 * 60.0 * 24.0);
 
             // Adjust statement below - if true it will not show the warning (e.g. for small datasets)
-            if (nDays*nChannels < 2)
-                setUserConfirm('loading')
+            if (nDays * nChannels < 2)
+                setUserConfirm('loading');
         }
         if (userConfirm == 'loading') {
             const h = LoadTest();
-            return () => { if (h != null && h.abort != null) h.abort(); }   
+            return () => { if (h != null && h.abort != null) h.abort(); };
         }
-    }, [userConfirm])
+    }, [userConfirm]);
 
     React.useEffect(() => { setChannelList((old) => { return _.orderBy(old, [sort], [asc ? "asc" : "desc"]) }) }, [asc, sort]);
 
@@ -231,10 +231,8 @@ const WizardTest = (props: IProps) => {
                     </div>
                     <div className="row" style={{ margin: 0 }}>
                         <div className="col">
-                            <button type="button" className={"btn btn-primary btn-block"} disabled={loading != 'changed' || !validEndDate || !validStartDate} onClick={() => {
-                               setUserConfirm('confirm')
-                            }}>
-                                    Test
+                            <button type="button" className={"btn btn-primary btn-block"} disabled={loading != 'changed' || !validEndDate || !validStartDate} onClick={() => setUserConfirm('confirm')}>
+                                Test
                             </button>
                         </div>
                         
@@ -348,14 +346,12 @@ const WizardTest = (props: IProps) => {
                 </div>
             </div>
             <Warning  Title={'This operation may take some time to process.'}
-                CallBack={(c) => {if (c) setUserConfirm('loading'); else setUserConfirm('uninitialized')}}
+                CallBack={(c) => { if (c) setUserConfirm('loading'); else setUserConfirm('uninitialized'); }}
                 Show={userConfirm == 'confirm'}
                 Message={'This operation may take some time to process. To speed up testing these setpoints please select a shorter timeframe or fewer channels.'}
                 ShowCancel={true}
             />
-           
-            
-        </div>      
+        </div>
     );
 }
 

--- a/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/SetpointParseSlice.ts
+++ b/Source/Applications/openXDA/openXDA/wwwroot/SPCTools/Scripts/TSX/store/SetpointParseSlice.ts
@@ -27,8 +27,14 @@ import _ from 'lodash';
 import { SelectStatisticsFilter, SelectStatisticsrange, SelectStatisticsChannels, SelectActiveAlarmValue } from '../Wizard/DynamicWizzardSlice';
 
 interface ParsedSetpointParam { content: DynamicWizzard.ITokenParseResponse, channelIDs: number[] }
+
+const fetchHandle;
+
 // #region [ Thunks ]
 export const FetchParsedSetPoint = createAsyncThunk('SetPointParse/FetchParsedSetPoint', async (param: { AlarmDayID: number, StartHour: number }, { getState, dispatch }) => {
+    if (fetchHandle != null && fetchHandle.abort != null)
+        fetchHandle.abort();
+
     let dataFilter = SelectStatisticsFilter(getState() as Redux.StoreState);
     let timeRange = SelectStatisticsrange(getState() as Redux.StoreState);
     let channelIDs = SelectStatisticsChannels(getState() as Redux.StoreState).map(ch => ch.ID);
@@ -40,7 +46,9 @@ export const FetchParsedSetPoint = createAsyncThunk('SetPointParse/FetchParsedSe
     if (token.Formula == "") {
         return Promise.resolve({ content: { Valid: false, IsScalar: false, Message: "Expression can not be empty.", Value: [] }, channelIDs: channelIDs } as ParsedSetpointParam);
     }
-    let handle = await GetParsedSetPoint(token, dataFilter, timeRange.start, timeRange.end, channelIDs);
+    fetchHandle = GetParsedSetPoint(token, dataFilter, timeRange.start, timeRange.end, channelIDs);
+    let handle = await fetchHandle;
+   
     return { content: handle, channelIDs: channelIDs };
 });
 
@@ -139,7 +147,7 @@ async function GetParsedSetPoint(token: DynamicWizzard.IAlarmvalue, dataFilter: 
         StatisticsEnd: end,
         StatisticsChannelID: channelIDs,
     }
-    return await $.ajax({
+    return $.ajax({
         type: "POST",
         url: `${apiHomePath}api/SPCTools/Token/Parse`,
         contentType: "application/json; charset=utf-8",

--- a/Source/Libraries/SPCTools/ExpressionOperations.cs
+++ b/Source/Libraries/SPCTools/ExpressionOperations.cs
@@ -94,6 +94,8 @@ namespace SPCTools
             else if (operand is Slice)
             {
                 Slice slice = operand as Slice;
+                if (slice.Values.Count() == 0)
+                    return new Scalar(0.0D)
                 return new Scalar(slice.Values.Min());
             }
             else if (operand is Matrix)
@@ -120,6 +122,8 @@ namespace SPCTools
             else if (operand is Slice)
             {
                 Slice slice = operand as Slice;
+                if (slice.Values.Count() == 0)
+                    return new Scalar(0.0D)
                 return new Scalar(slice.Values.Max());
             }
             else if (operand is Matrix)
@@ -146,6 +150,8 @@ namespace SPCTools
             else if (operand is Slice)
             {
                 Slice slice = operand as Slice;
+                if (slice.Values.Count() == 0)
+                    return new Scalar(0.0D)
                 return new Scalar(slice.Values.Sum() / slice.Values.Count());
             }
             else if (operand is Matrix)
@@ -203,7 +209,9 @@ namespace SPCTools
             else if (operand is Slice)
             {
                 Slice slice = operand as Slice;
-                double maxValue = slice.Values.Min();
+                double maxValue = 0.0D;
+                if (slice.Values.Count() > 0)
+                    maxValue = slice.Values.Min();
                 return new Slice(slice.Values.Select(_ => maxValue).ToList());
             }
             else if (operand is Matrix)
@@ -230,7 +238,9 @@ namespace SPCTools
             else if (operand is Slice)
             {
                 Slice slice = operand as Slice;
-                double maxValue = slice.Values.Max();
+                double maxValue = 0.0D;
+                 if (slice.Values.Count() > 0)
+                    maxValue = slice.Values.Max();
                 return new Slice(slice.Values.Select(_ => maxValue).ToList());
             }
             else if (operand is Matrix)
@@ -257,7 +267,7 @@ namespace SPCTools
             else if (operand is Slice)
             {
                 Slice slice = operand as Slice;
-                double min = slice.Values.Min();
+                double min = slice.Values.Sum()/slice.Values.Count();
                 return new Slice(slice.Values.Select(_ => min).ToList());
             }
             else if (operand is Matrix)

--- a/Source/Libraries/SPCTools/ExpressionOperations.cs
+++ b/Source/Libraries/SPCTools/ExpressionOperations.cs
@@ -95,7 +95,7 @@ namespace SPCTools
             {
                 Slice slice = operand as Slice;
                 if (slice.Values.Count() == 0)
-                    return new Scalar(0.0D)
+                    return new Scalar(0.0D);
                 return new Scalar(slice.Values.Min());
             }
             else if (operand is Matrix)
@@ -123,7 +123,7 @@ namespace SPCTools
             {
                 Slice slice = operand as Slice;
                 if (slice.Values.Count() == 0)
-                    return new Scalar(0.0D)
+                    return new Scalar(0.0D);
                 return new Scalar(slice.Values.Max());
             }
             else if (operand is Matrix)
@@ -151,7 +151,7 @@ namespace SPCTools
             {
                 Slice slice = operand as Slice;
                 if (slice.Values.Count() == 0)
-                    return new Scalar(0.0D)
+                    return new Scalar(0.0D);
                 return new Scalar(slice.Values.Sum() / slice.Values.Count());
             }
             else if (operand is Matrix)

--- a/Source/Libraries/SPCTools/Matrix.cs
+++ b/Source/Libraries/SPCTools/Matrix.cs
@@ -29,9 +29,9 @@ namespace SPCTools
 {
     public class Matrix : IExpressionOperands
     {
-        public List<List<double[]>> Values { get; private set; }
+        public List<IAsyncEnumerable<double[]>> Values { get; private set; }
 
-        public Matrix(List<List<double[]>> values)
+        public Matrix(List<IAsyncEnumerable<double[]>> values)
         {
             Values = values;
         }
@@ -58,7 +58,7 @@ namespace SPCTools
             else if (obj is Matrix)
             {
                 Matrix mat = obj as Matrix;
-                List<List<double[]>> result = mat.Values.Select((row, i) => row.Select((point, j) => new double[] { point[0], point[1] - matrix.Values[i][j][1] }).ToList()).ToList();
+                List<IAsyncEnumerable<double[]>> result = mat.Values.Select((row, i) => row.Zip(matrix.Values[i], (matPoint, matrixPoint) => new double[] { matPoint[0], matPoint[1] - matrixPoint[1] })).ToList();
                 return new Matrix(result);
             }
 
@@ -96,7 +96,7 @@ namespace SPCTools
             else if (obj is Matrix)
             {
                 Matrix mat = obj as Matrix;
-                List<List<double[]>> result = mat.Values.Select((row, i) => row.Select((point, j) => new double[] { point[0], point[1] + matrix.Values[i][j][1] }).ToList()).ToList();
+                List<IAsyncEnumerable<double[]>> result = mat.Values.Select((row, i) => row.Zip(matrix.Values[i], (matPoint, matrixPoint) => new double[] { matPoint[0], matPoint[1] + matrixPoint[1] })).ToList();
                 return new Matrix(result);
             }
 
@@ -134,7 +134,7 @@ namespace SPCTools
             else if (obj is Matrix)
             {
                 Matrix mat = obj as Matrix;
-                List<List<double[]>> result = mat.Values.Select((row, i) => row.Select((point, j) => new double[] { point[0], point[1] * matrix.Values[i][j][1] }).ToList()).ToList();
+                List<IAsyncEnumerable<double[]>> result = mat.Values.Select((row, i) => row.Zip(matrix.Values[i], (matPoint, matrixPoint) => new double[] { matPoint[0], matPoint[1] * matrixPoint[1] })).ToList();
                 return new Matrix(result);
             }
 
@@ -160,19 +160,19 @@ namespace SPCTools
             if (obj is Scalar)
             {
                 Scalar scalar = obj as Scalar;
-                List<List<double[]>> result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], scalar.Value / point[1] }).ToList()).ToList();
+                List<IAsyncEnumerable<double[]>> result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], scalar.Value / point[1] })).ToList();
                 return new Matrix(result);
             }
             else if (obj is Slice)
             {
                 Slice slice = obj as Slice;
-                List<List<double[]>> result = matrix.Values.Select((row, i) => row.Select(point => new double[] { point[0], slice.Values[i] / point[1] }).ToList()).ToList();
+                List<IAsyncEnumerable<double[]>> result = matrix.Values.Select((row, i) => row.Select(point => new double[] { point[0], slice.Values[i] / point[1] })).ToList();
                 return new Matrix(result);
             }
             else if (obj is Matrix)
             {
                 Matrix mat = obj as Matrix;
-                List<List<double[]>> result = mat.Values.Select((row, i) => row.Select((point, j) => new double[] { point[0], point[1] / matrix.Values[i][j][1] }).ToList()).ToList();
+                List<IAsyncEnumerable<double[]>> result = mat.Values.Select((row, i) => row.Zip(matrix.Values[i], (matPoint, matrixPoint) => new double[] { matPoint[0], matPoint[1] / matrixPoint[1] })).ToList();
                 return new Matrix(result);
             }
 
@@ -196,13 +196,13 @@ namespace SPCTools
         //Unary Operator Overloads
         public static Matrix operator -(Matrix matrix)
         {
-            var result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], -point[1] }).ToList()).ToList();
+            var result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], -point[1] })).ToList();
             return new Matrix(result);
         }
 
         public static Matrix operator +(Matrix matrix)
         {
-            var result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], +point[1] }).ToList()).ToList();
+            var result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], +point[1] })).ToList();
             return new Matrix(result);
         }
     }

--- a/Source/Libraries/SPCTools/Scalar.cs
+++ b/Source/Libraries/SPCTools/Scalar.cs
@@ -59,7 +59,7 @@ namespace SPCTools
             else if (obj is Matrix)
             {
                 Matrix matrix = obj as Matrix;
-                List<List<double[]>> result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], point[1] + scalar.Value }).ToList()).ToList();
+                List<IAsyncEnumerable<double[]>> result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], point[1] + scalar.Value })).ToList();
                 return new Matrix(result);
             }
 
@@ -93,7 +93,7 @@ namespace SPCTools
             else if (obj is Matrix)
             {
                 Matrix matrix = obj as Matrix;
-                var result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], point[1] - scalar.Value }).ToList()).ToList();
+                var result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], point[1] - scalar.Value })).ToList();
                 return new Matrix(result);
             }
 
@@ -128,7 +128,7 @@ namespace SPCTools
             else if (obj is Matrix)
             {
                 Matrix matrix = obj as Matrix;
-                List<List<double[]>> result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], point[1] * scalar.Value }).ToList()).ToList();
+                List<IAsyncEnumerable<double[]>> result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], point[1] * scalar.Value })).ToList();
                 return new Matrix(result);
             }
 
@@ -165,7 +165,7 @@ namespace SPCTools
             else if (obj is Matrix)
             {
                 Matrix matrix = obj as Matrix;
-                List<List<double[]>> result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], point[1] / scalar.Value }).ToList()).ToList();
+                List<IAsyncEnumerable<double[]>> result = matrix.Values.Select(row => row.Select(point => new double[] { point[0], point[1] / scalar.Value })).ToList();
                 return new Matrix(result);
             }
 

--- a/Source/Libraries/SPCTools/Slice.cs
+++ b/Source/Libraries/SPCTools/Slice.cs
@@ -65,7 +65,7 @@ namespace SPCTools
             else if (obj is Matrix)
             {
                 Matrix matrix = obj as Matrix;
-                List<List<double[]>> result = matrix.Values.Select((row, i) => row.Select(point => new double[] { point[0], point[1] + slice.Values[i] }).ToList()).ToList();
+                List<IAsyncEnumerable<double[]>> result = matrix.Values.Select((row, i) => row.Select(point => new double[] { point[0], point[1] + slice.Values[i] })).ToList();
                 return new Matrix(result);
             }
 
@@ -104,7 +104,7 @@ namespace SPCTools
             else if (obj is Matrix)
             {
                 Matrix matrix = obj as Matrix;
-                List<List<double[]>> result = matrix.Values.Select((row, i) => row.Select(point => new double[] { point[0], point[1] * slice.Values[i] }).ToList()).ToList();
+                List<IAsyncEnumerable<double[]>> result = matrix.Values.Select((row, i) => row.Select(point => new double[] { point[0], point[1] * slice.Values[i] })).ToList();
                 return new Matrix(result);
             }
 
@@ -143,7 +143,7 @@ namespace SPCTools
             else if (obj is Matrix)
             {
                 Matrix matrix = obj as Matrix;
-                List<List<double[]>> result = matrix.Values.Select((row, i) => row.Select(point => new double[] { point[0], point[1] - slice.Values[i] }).ToList()).ToList();
+                List<IAsyncEnumerable<double[]>> result = matrix.Values.Select((row, i) => row.Select(point => new double[] { point[0], point[1] - slice.Values[i] })).ToList();
                 return new Matrix(result);
             }
 
@@ -190,7 +190,7 @@ namespace SPCTools
             {
                 //Probably should add checks to see if the lists are same size..
                 Matrix matrix = obj as Matrix;
-                List<List<double[]>> result = matrix.Values.Select((row, i) => row.Select(point => new double[] { point[0], point[1] / slice.Values[i] }).ToList()).ToList();
+                List<IAsyncEnumerable<double[]>> result = matrix.Values.Select((row, i) => row.Select(point => new double[] { point[0], point[1] / slice.Values[i] })).ToList();
                 return new Matrix(result);
             }
 

--- a/Source/Libraries/SPCTools/WizardController.cs
+++ b/Source/Libraries/SPCTools/WizardController.cs
@@ -145,13 +145,15 @@ namespace SPCTools
                         Alarm alarm = null;
                         int seriesID = connection.ExecuteScalar<int>($"SELECT Top 1 ID FROM Series WHERE ChannelID = {item} AND SeriesTypeID = {request.SeriesTypeID}");
                         int alarmID = 0;
+
                         if (!isNew)
                         {
                             alarm = alarmTbl.QueryRecordWhere("AlarmGroupID = {0} AND SeriesID = {1}", alarmgroupID, seriesID);
-                            alarmID = alarm.ID;
-
+                            if (!(alarm is null))
+                                alarmID = alarm.ID;
                         }
-                        if (isNew || alarm == null)
+
+                        if (isNew || alarm is null)
                         {
                             alarm = new Alarm()
                             {
@@ -162,6 +164,7 @@ namespace SPCTools
                             alarmTbl.AddNewRecord(alarm);
                             alarmID = connection.ExecuteScalar<int>("SELECT @@IDENTITY");
                         }
+
                         if (!alarm.Manual)
                             updateAlarmID.Add(new Tuple<int, int>(alarmID, item));
 
@@ -179,7 +182,7 @@ namespace SPCTools
                         {
                             if (!isNew)
                             {
-                                connection.ExecuteNonQuery($"DELETE AlarmValue WHERE AlarmID = {alarmID.Item1} AND StartHour = {value.StartHour} AND AlarmDayID {(value.AlarmDayID == null ? "IS NULL" : ("= " + value.AlarmDayID.ToString()))}");
+                                connection.ExecuteNonQuery($"DELETE AlarmValue WHERE AlarmID = {alarmID.Item1} AND StartHour = {value.StartHour} AND AlarmDayID {(value.AlarmDayID is null ? "IS NULL" : ("= " + value.AlarmDayID.ToString()))}");
                             
                             }
                             AlarmValue alarmValue = new AlarmValue()


### PR DESCRIPTION
The default query of one month was way too large for some data sets. This change prevents the query from executing automatically and warns the user if the query grows above (an extremely rough) 1 MB estimate.