### PR TITLE
Add props to ScheduledEmailType model

### DIFF
--- a/Source/Libraries/openXDA.Model/Emails/ScheduledEmailType.cs
+++ b/Source/Libraries/openXDA.Model/Emails/ScheduledEmailType.cs
@@ -40,6 +40,10 @@ namespace openXDA.Model
         public string Schedule { get; set; }
 
         public int EmailCategoryID { get; set; }
+
+        public bool ShowSubscription { get; set; }
+
+        public bool RequireApproval { get; set; }
     }
 }
 


### PR DESCRIPTION
Add ShowSubscription and RequireApproval props to ScheduledEmailType model. Necessary for SC-45.