### PR TITLE
Fixed Typing on Endpoint

### DIFF
--- a/Source/Applications/openXDA/openXDA/Controllers/Workbench/DataFileController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/Workbench/DataFileController.cs
@@ -182,15 +182,13 @@ namespace openXDA.Controllers.Config
         }
 
         [Route("ReprocessFilesByID"), HttpPost]
-        public async Task<int> ReprocessFiles([FromBody] JObject fileGroupIDs)
+        public async Task<int> ReprocessFiles([FromBody] IEnumerable<int> fileGroupIDs)
         {
-            List<int> fileGroupIDList = fileGroupIDs.ToObject<List<int>>();
-
             using (AdoDataConnection connection = NodeHost.CreateDbConnection())
             {
                 List<Task> reprocessTasks = new List<Task>();
 
-                foreach (int fileGroupID in fileGroupIDList)
+                foreach (int fileGroupID in fileGroupIDs)
                 {
                     CascadeDelete(connection, "Event", $"FileGroupID = {fileGroupID}");
                     CascadeDelete(connection, "EventData", $"FileGroupID = {fileGroupID}");


### PR DESCRIPTION
Fixed Typing to accept an array of int rather than a `JObject`