### PR TITLE
Apply sqrt(2) adjustment based on setting

### DIFF
--- a/Source/Data/05 - DefaultSettings.sql
+++ b/Source/Data/05 - DefaultSettings.sql
@@ -25,6 +25,9 @@ GO
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('COMTRADE.MinWaitTime', '15.0', '15.0')
 GO
 
+INSERT INTO Setting(Name, Value, DefaultValue) VALUES('COMTRADE.Root2AdjustmentQuery', 'SELECT ID FROM Meter WHERE Make = ''SEL''', 'SELECT ID FROM Meter WHERE Make = ''SEL''')
+GO
+
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('COMTRADE.UseRelaxedValidation', 'False', 'False')
 GO
 

--- a/Source/Libraries/openXDA.Configuration/COMTRADESection.cs
+++ b/Source/Libraries/openXDA.Configuration/COMTRADESection.cs
@@ -50,6 +50,10 @@ namespace openXDA.Configuration
         public bool UseRelaxedValidation { get; set; }
 
         [Setting]
+        [DefaultValue("SELECT ID FROM Meter WHERE Make = 'SEL'")]
+        public string Root2AdjustmentQuery { get; set; }
+
+        [Setting]
         [SettingName(nameof(MinWaitTime))]
         [DefaultValue(15.0D)]
         [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
I had a hard time figuring out where this should go and what restrictions to apply. Here's a punchlist summary.

* Given that CEV files exclusively come from SEL devices, the `sqrt(2)` multiplier is already hardcoded. EVE files don't have the multiplier applied, but they probably should. The only other format I've encountered that requires this multiplier is COMTRADE, so I have explicitly limited it to COMTRADE files. IIRC, the only other devices I've encountered that may require this setting are Mehta Tech DFRs, which also use COMTRADE.
* COMTRADE provides a limited amount of metadata about channels so I simply make the assumption that the multiplier should be applied to all channels unconditionally. This is not an informed decision based on documentation from any particular device manufacturer or example files from the devices themselves, but rather an arbitrary decision with no basis other than the fact that it's the simplest form of compromise between not applying the multiplier to any channels and having to specify the multiplier on a per-channel basis.
* By default, it only applies this multiplier to SEL devices based on the `Device.Make` field. We could maybe include Mehta Tech, but I have a suspicion that they may have changed this behavior in newer models. Also, there are fewer ways to spell "SEL".