### PR TITLE
XDA-30 Remove UNIQUE CONSTRAINT from LocationDrawing.

### DIFF
--- a/Source/Data/09 - SystemCenter.sql
+++ b/Source/Data/09 - SystemCenter.sql
@@ -266,8 +266,7 @@ CREATE TABLE [LocationDrawing] (
     Link VARCHAR(max) NOT NUll,
     Description VARCHAR(max) NULL,
     Number VARCHAR(200) NULL,
-    Category VARCHAR(max) NULL,
-    CONSTRAINT UC_SystemCenter_LocationDrawing_Number UNIQUE (Number)
+    Category VARCHAR(max) NULL
 )
 GO
 


### PR DESCRIPTION
Remove constraint from LocationDrawing as Number is not a required field in the UI and causes issues with adding a drawing without a Number.