### PR TITLE
XDA-34 Assign DataGroup.Asset to data groups with reported disturbances

### DIFF
--- a/Source/Libraries/FaultData/DataAnalysis/VoltageDisturbanceAnalyzer.cs
+++ b/Source/Libraries/FaultData/DataAnalysis/VoltageDisturbanceAnalyzer.cs
@@ -125,14 +125,6 @@ namespace FaultData.DataAnalysis
         {
             Asset asset = dataGroup.Asset;
 
-            if ((object)asset == null)
-            {
-                if (meter.Location.AssetLocations.Count != 1)
-                    return;
-
-                asset = meter.Location.AssetLocations.Single().Asset;
-            }
-
             List<Disturbance> disturbanceList = dataGroup.Disturbances
                 .Select(disturbance => ToDisturbance(asset, disturbance))
                 .Where(IsDisturbed)

--- a/Source/Libraries/FaultData/DataOperations/EventOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/EventOperation.cs
@@ -117,7 +117,7 @@ namespace FaultData.DataOperations
                     if (dataGroup.Classification != DataClassification.Event)
                         continue;
 
-                    Asset asset = dataGroup.Asset ?? meterDataSet.Meter.Location.AssetLocations.Single().Asset;
+                    Asset asset = dataGroup.Asset;
                     IDbDataParameter startTime2 = ToDateTime2(connection, dataGroup.StartTime);
                     IDbDataParameter endTime2 = ToDateTime2(connection, dataGroup.EndTime);
 
@@ -177,10 +177,7 @@ namespace FaultData.DataOperations
                 if (!eventClassifications.TryGetValue(dataGroup, out EventClassification eventClassification))
                     continue;
 
-                if ((object)dataGroup.Asset == null && meterDataSet.Meter.Location.AssetLocations.Count != 1)
-                    continue;
-
-                Asset asset = dataGroup.Asset ?? meterDataSet.Meter.Location.AssetLocations.Single().Asset;
+                Asset asset = dataGroup.Asset;
                 IDbDataParameter startTime2 = ToDateTime2(connection, dataGroup.StartTime);
                 IDbDataParameter endTime2 = ToDateTime2(connection, dataGroup.EndTime);
 

--- a/Source/Libraries/FaultData/DataResources/DataGroupsResource.cs
+++ b/Source/Libraries/FaultData/DataResources/DataGroupsResource.cs
@@ -98,13 +98,15 @@ namespace FaultData.DataResources
 
             if (meterDataSet.Meter.MeterAssets.Count == 1)
             {
+                Asset asset = meterDataSet.Meter.MeterAssets[0].Asset;
+
                 foreach (ReportedDisturbance disturbance in meterDataSet.ReportedDisturbances.OrderBy(dist => dist.Time))
                 {
                     DataGroup dataGroup = dataGroups.FirstOrDefault(dg => dg.Add(disturbance));
 
                     if ((object)dataGroup == null)
                     {
-                        dataGroup = new DataGroup();
+                        dataGroup = new DataGroup(asset);
                         dataGroup.Add(disturbance);
                         dataGroups.Add(dataGroup);
                     }

--- a/Source/Libraries/FaultData/DataResources/EventClassificationResource.cs
+++ b/Source/Libraries/FaultData/DataResources/EventClassificationResource.cs
@@ -101,7 +101,7 @@ namespace FaultData.DataResources
 
                 EventClassification classification = Classify(meterDataSet, dataGroup);
 
-                if (!(dataGroup.Asset is null) && !ValidateEventType(classification, dataGroup.Asset))
+                if (!ValidateEventType(classification, dataGroup.Asset))
                     classification = EventClassification.Other;
 
                 Classifications.Add(dataGroup, classification);
@@ -176,7 +176,7 @@ namespace FaultData.DataResources
 
                 EventTypeAssetType evtAssetType = new TableOperations<EventTypeAssetType>(connection).QueryRecordWhere("EventTypeID = {0} AND AssetTypeID = {1}", evtType.ID, asset.AssetTypeID);
                 return !(evtAssetType is null);
-            }        
+            }
         }
 
         private static bool HasBreakerChannels(DataGroup dataGroup)


### PR DESCRIPTION
It was surprisingly easy. None of the code was explicitly filtering by `dataGroup.Asset != null`. Instead, they would reference data groups from `CycleDataResource` which filters down to data groups that have 3 voltages and 3 currents.

The only code that cared about whether `dataGroup.Asset == null` was code that was processing reported disturbances, in which case it would try to use a fallback or bypass some non-critical logic. In all cases, it's easier and better to just assign the asset to the data group on creation and remove all the null checks.