### PR TITLE
Added DefaultValue Expression

### DIFF
--- a/Source/Libraries/openXDA.Model/Security/ApplicationNode.cs
+++ b/Source/Libraries/openXDA.Model/Security/ApplicationNode.cs
@@ -26,6 +26,7 @@ using GSF.Data.Model;
 using GSF.Security;
 using GSF.Security.Model;
 using System;
+using System.ComponentModel;
 
 namespace openXDA.Model
 {
@@ -38,6 +39,7 @@ namespace openXDA.Model
     public class ApplicationNode
     {
         [PrimaryKey(true)]
+        [DefaultValue("00000000-0000-0000-0000-000000000001")]
         public Guid ID { get; set; }
         public string Name { get; set; }
     }

--- a/Source/Libraries/openXDA.Model/Security/ApplicationNode.cs
+++ b/Source/Libraries/openXDA.Model/Security/ApplicationNode.cs
@@ -39,7 +39,7 @@ namespace openXDA.Model
     public class ApplicationNode
     {
         [PrimaryKey(true)]
-        [DefaultValue("00000000-0000-0000-0000-000000000001")]
+        [DefaultValue(typeof(Guid), "00000000-0000-0000-0000-000000000001")]
         public Guid ID { get; set; }
         public string Name { get; set; }
     }


### PR DESCRIPTION
This addresses the issue with openXDA having a default ID of `0` 
The model is only used in the UI (`TableOperations` causes the problem when the GUID matches the default so this should address it)
