### PR TITLE
AllowSearch on EventType

### DIFF
--- a/Source/Libraries/openXDA.Model/Events/EventType.cs
+++ b/Source/Libraries/openXDA.Model/Events/EventType.cs
@@ -29,6 +29,7 @@ using GSF.Data.Model;
 namespace openXDA.Model
 {
     [SettingsCategory("systemSettings")]
+    [AllowSearch]
     public class EventType
     {
         [PrimaryKey(true)]


### PR DESCRIPTION
EventType Model now allows for searching.
Dependency for [Updated-ByPages](https://github.com/GridProtectionAlliance/SystemCenter/pull/549).