### PR TITLE
Generate exceptions when testing remote XDA connection

### DIFF
--- a/Source/Libraries/openXDA.DataPusher/WebAPIHub.cs
+++ b/Source/Libraries/openXDA.DataPusher/WebAPIHub.cs
@@ -172,7 +172,8 @@ namespace openXDA.DataPusher
             {
                 using (HttpResponseMessage response = await requester.SendRequestAsync("api/PQMark/Alive", HttpMethod.Get))
                 {
-                    return (response.IsSuccessStatusCode, null);
+                    response.EnsureSuccessStatusCode();
+                    return (true, null);
                 }
             }
             catch (Exception ex)//Exception here is a fail state, must be caught reported back so that testers know the failpoint is downstream


### PR DESCRIPTION
The try-catch in `TestConnection()` was almost entirely useless because `IsSuccessStatusCode` only tells you whether or not the status code is between 200-299. You can see that it was not successful, but not what the failure code actually is. `EnsureSuccessStatusCode()` will throw an exception if status code is not 200-299, and the exception message ought to show us what the status code is.

I'm not sure what kind of inner exceptions we were expecting to encounter in `TestRemoteInstanceConnection()`, especially considering we weren't even invoking `EnsureSuccessStatusCode()`. Unless we actually know something about the exceptions we expect to encounter, we probably shouldn't be making assumptions about whether we need to see the outer exception message or the inner one. The fact that it wasn't providing useful feedback suggests to me we don't know enough about the exceptions being thrown to really make that call.

I wanted to call `ex.ToString()` and include the stack trace, but it seems that System Center is displaying this message in the format...

> Connection could not be made to remote XDA server. ${testErrorMessage}

So instead I chose to return exception messages with no stack trace in the following format...

> Outer exception message ([1] Inner exception message) ([2] Inner exception message) ...

Honestly, it seems a little unsafe to return data from catch-all exception handlers to the client without any sort of validation, but all I'm looking to do for now is improve the situation.