### PR TITLE
Improve performance for Asset.DistanceToAsset()

### DIFF
--- a/Source/Libraries/FaultData/DataAnalysis/VIDataGroup.cs
+++ b/Source/Libraries/FaultData/DataAnalysis/VIDataGroup.cs
@@ -162,6 +162,8 @@ namespace FaultData.DataAnalysis
                     return 1;
                 if (a.AllVoltagesDefined && !b.AllVoltagesDefined)
                     return -1;
+                if (!(a.Distance >= 0 && b.Distance >= 0))
+                    return b.Distance.CompareTo(a.Distance);
                 return a.Distance.CompareTo(b.Distance);
             });
         }


### PR DESCRIPTION
Trace logs from TVA suggest this method may be taking a very long time, and it is clearly not optimized. I removed the recursion in favor of a breadth first search so we can bail at the earliest moment, once we've found the asset we're looking for. This will also help to avoid repeatedly computing distance for the same assets just because they were in different branches of the recursive search. Furthermore, the hash set will speed up checks to see if we've already visited an asset.