### PR TITLE
Fix infinite recursion when querying connected channels

### DIFF
--- a/Source/Libraries/openXDA.Model/TransmissionElements/Asset.cs
+++ b/Source/Libraries/openXDA.Model/TransmissionElements/Asset.cs
@@ -388,7 +388,6 @@ namespace openXDA.Model
                 }
 
                 potentials = remoteAsset.GetConnectedChannel(connection, ignoredAssets, alowedLocations);
-                ignoredAssets.Pop();
 
                 foreach (Channel channel in potentials)
                 {
@@ -399,6 +398,8 @@ namespace openXDA.Model
                     }
                 }
             }
+
+            ignoredAssets.Pop();
 
             return result.Distinct(new ChannelComparer());
         }


### PR DESCRIPTION
Popping the entry off the stack too early causes subsequent iterations of the loop to fail to ignore the asset, causing us to fail to detect circular references in some cases.