### PR TITLE
Daily statistics fix

### DIFF
--- a/Source/Data/01 - openXDA.sql
+++ b/Source/Data/01 - openXDA.sql
@@ -241,6 +241,15 @@ CREATE TABLE DataOperationFailure
 )
 GO
 
+CREATE NONCLUSTERED INDEX IX_DataOperationFailure_DataOperationID
+ON DataOperationFailure(DataOperationID ASC)
+GO
+
+
+CREATE NONCLUSTERED INDEX IX_DataOperationFailure_FileGroupID
+ON DataOperationFailure(FileGroupID ASC)
+GO
+
 CREATE TABLE HostRegistration
 (
     ID INT IDENTITY(1, 1) NOT NULL PRIMARY KEY,

--- a/Source/Data/01 - openXDA.sql
+++ b/Source/Data/01 - openXDA.sql
@@ -2074,9 +2074,6 @@ GO
 INSERT INTO DataOperation(AssemblyName, TypeName, LoadOrder) VALUES('FaultData.dll', 'FaultData.DataOperations.RelayEnergization', 13)
 GO
 
-INSERT INTO DataOperation(AssemblyName, TypeName, LoadOrder) VALUES('FaultData.dll', 'FaultData.DataOperations.DailyStatisticOperation', 14)
-GO
-
 INSERT INTO DataOperation(AssemblyName, TypeName, LoadOrder) VALUES('FaultData.dll', 'FaultData.DataOperations.LSCVSDataOperation', 15)
 GO
 

--- a/Source/Data/01 - openXDA.sql
+++ b/Source/Data/01 - openXDA.sql
@@ -245,7 +245,6 @@ CREATE NONCLUSTERED INDEX IX_DataOperationFailure_DataOperationID
 ON DataOperationFailure(DataOperationID ASC)
 GO
 
-
 CREATE NONCLUSTERED INDEX IX_DataOperationFailure_FileGroupID
 ON DataOperationFailure(FileGroupID ASC)
 GO
@@ -2074,7 +2073,7 @@ GO
 INSERT INTO DataOperation(AssemblyName, TypeName, LoadOrder) VALUES('FaultData.dll', 'FaultData.DataOperations.RelayEnergization', 13)
 GO
 
-INSERT INTO DataOperation(AssemblyName, TypeName, LoadOrder) VALUES('FaultData.dll', 'FaultData.DataOperations.LSCVSDataOperation', 15)
+INSERT INTO DataOperation(AssemblyName, TypeName, LoadOrder) VALUES('FaultData.dll', 'FaultData.DataOperations.LSCVSDataOperation', 14)
 GO
 
 INSERT INTO AssetGroup(Name, DisplayDashboard, DisplayEmail) VALUES('AllAssets', 1, 1)

--- a/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
@@ -975,10 +975,15 @@ namespace FaultData.DataOperations
         /// Checks if the Trigger Trend Channels exist and adds them if necesarry.
         /// </summary>
         /// <param name="powChannel">The point on Wave Data Channel.</param>
-        /// <param name="triggerIndices">Source Indices of the existing Trigger Trend Channels.</param>
         /// <param name="meterDataSet"><see cref="MeterDataSet"/></param>
         private void AddTriggerChannel(Channel powChannel, MeterDataSet meterDataSet)
         {
+            if (powChannel is null)
+            {
+                Log.Warn("Attempted to add a trigger channel without corrsponding pow Channel. This channel will be skipped.");
+
+                return;
+            }
             //Create new RMS Channel and Series
             Channel trendChannel = new Channel()
             {

--- a/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
@@ -1039,8 +1039,13 @@ namespace FaultData.DataOperations
                     measurementCharacteristic = "Instantaneous";
                     measurementType = "Current";
                 }
+                else
+                {
+                    Log.Warn($"Unknown trigger channel type for channel {trendChannel.Name}. This channel will be skipped.");
+                    return;
+                }
 
-                trendChannel.MeasurementCharacteristic = measurementCharacteristicTable.QueryRecordWhere("Name ={0}", measurementCharacteristic);
+                trendChannel.MeasurementCharacteristic = measurementCharacteristicTable.QueryRecordWhere("Name = {0}", measurementCharacteristic);
                 trendChannel.MeasurementCharacteristicID = trendChannel.MeasurementCharacteristic.ID;
 
                 trendChannel.MeasurementType = measurementTypeTable.QueryRecordWhere("Name = {0}", measurementType);

--- a/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
@@ -978,12 +978,6 @@ namespace FaultData.DataOperations
         /// <param name="meterDataSet"><see cref="MeterDataSet"/></param>
         private void AddTriggerChannel(Channel powChannel, MeterDataSet meterDataSet)
         {
-            if (powChannel is null)
-            {
-                Log.Warn("Attempted to add a trigger channel without corrsponding pow Channel. This channel will be skipped.");
-
-                return;
-            }
             //Create new RMS Channel and Series
             Channel trendChannel = new Channel()
             {

--- a/Source/Libraries/openXDA.MATLAB/MATLABAnalytic.cs
+++ b/Source/Libraries/openXDA.MATLAB/MATLABAnalytic.cs
@@ -171,11 +171,12 @@ namespace openXDA.MATLAB
         private static MWArray ToMWArray(DataSeries[] dataSeriesList)
         {
             double GetValue(DataSeries dataSeries, int index) =>
-                (index <= dataSeries.DataPoints.Count)
+                (!(dataSeries is null) && index <= dataSeries.DataPoints.Count)
                     ? dataSeries[index].Value
                     : double.NaN;
 
             int maxCount = dataSeriesList
+                .Where(dataSeries => !(dataSeries is null))
                 .Select(dataSeries => dataSeries.DataPoints.Count)
                 .DefaultIfEmpty(0)
                 .Max();

--- a/Source/Libraries/openXDA.Model/TransmissionElements/Line.cs
+++ b/Source/Libraries/openXDA.Model/TransmissionElements/Line.cs
@@ -176,7 +176,7 @@ namespace openXDA.Model
                 }
             }
 
-            return result.Where(item => item.Value.Count > 0).Select( item => new TransmissionPath()
+            return result.Where(item => item.Value.Count > 0).Select(item => new TransmissionPath()
             {
                 Length = item.Value.Select(seg => seg.Length).Sum(),
                 X0 = item.Value.Select(seg => seg.X0).Sum(),
@@ -209,7 +209,7 @@ namespace openXDA.Model
                 if (stack.Contains(segment.ID))
                 {
                     if (stack.Peek() != segment.ID)
-                        Log.Error($"Line {this.AssetKey} has a looped linesegement ({segment.AssetKey}). This is causing issues in fault distance computations.");
+                        Log.Error($"Line {this.AssetKey} has a looped line segment ({segment.AssetKey}). This is causing issues in fault distance computations.");
                     continue;
                 }
                 stack.Push(start.ID);
@@ -222,7 +222,7 @@ namespace openXDA.Model
                 }
             }
 
-           return new List<LineSegment>();          
+           return new List<LineSegment>();
         }
 
         /// <summary>
@@ -241,6 +241,14 @@ namespace openXDA.Model
             });
         }
 
+        #endregion
+
+        #region [ Static ]
+
+        // Static Fields
+        private static readonly ILog Log = LogManager.GetLogger(typeof(Line));
+
+        // Static Methods
         public static Line DetailedLine(Asset asset, AdoDataConnection connection)
         {
             if (connection is null)
@@ -265,9 +273,8 @@ namespace openXDA.Model
                 return DetailedLine(asset, connection);
             }
         }
-        #endregion
 
-        private static readonly ILog Log = LogManager.GetLogger(typeof(Line));
+        #endregion
     }
 
 

--- a/Source/Libraries/openXDA.Model/openXDA.Model.csproj
+++ b/Source/Libraries/openXDA.Model/openXDA.Model.csproj
@@ -47,6 +47,10 @@
     <Reference Include="Ionic.Zlib">
       <HintPath>..\..\Dependencies\DotNetZip\Ionic.Zlib.dll</HintPath>
     </Reference>
+    <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Dependencies\NuGet\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\Dependencies\GSF\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisNode.cs
@@ -189,8 +189,10 @@ namespace openXDA.Nodes.Types.Analysis
             try
             {
                 Meter meter = task.Meter;
-                Process(fileGroup, meter);
+                MeterDataSet meterDataset = Process(fileGroup, meter);
                 SaveMeterConfiguration(fileGroup, meter);
+                if (!(meterDataset is null))
+                    DailyStatisticOperation.UpdateSuccessFileProcessingStatistic(meterDataset, task.FileGroup);
             }
             catch (Exception ex)
             {
@@ -203,7 +205,7 @@ namespace openXDA.Nodes.Types.Analysis
                     fileGroup.ProcessingStatus = (int)FileGroupProcessingStatus.Failed;
                     UpdateFileGroup(fileGroup);
 
-                    DailyStatisticOperation.UpdateFileProcessingStatistic(task.Meter.AssetKey, task.FileGroup, message);
+                    DailyStatisticOperation.UpdateFailureFileProcessingStatistic(task.Meter.AssetKey, task.FileGroup, message);
                 }
                 catch (Exception e) {
                     Exception w = new Exception(message, e);
@@ -215,7 +217,7 @@ namespace openXDA.Nodes.Types.Analysis
             }
         }
 
-        private void Process(FileGroup fileGroup, Meter meter)
+        private MeterDataSet Process(FileGroup fileGroup, Meter meter)
         {
             DateTime startTime = DateTime.UtcNow;
             Action<object> configurator = GetConfigurator();
@@ -269,6 +271,8 @@ namespace openXDA.Nodes.Types.Analysis
             fileGroup.ProcessingEndTime = timeZoneConverter.ToXDATimeZone(endTime);
             fileGroup.ProcessingStatus = (int)processingStatus;
             UpdateFileGroup(fileGroup);
+
+            return meterDataSet;
         }
 
         private FileGroupProcessingStatus Process(MeterDataSet meterDataSet)

--- a/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisNode.cs
@@ -193,7 +193,7 @@ namespace openXDA.Nodes.Types.Analysis
                 MeterDataSet meterDataset = Process(fileGroup, meter);
                 SaveMeterConfiguration(fileGroup, meter);
                 if (!(meterDataset is null))
-                    DailyStatisticOperation.UpdateSuccessFileProcessingStatistic(meterDataset, task.FileGroup);
+                    DailyStatisticOperation.UpdateSuccessFileProcessingStatistic(meterDataset);
             }
             catch (Exception ex)
             {

--- a/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisNode.cs
@@ -165,6 +165,7 @@ namespace openXDA.Nodes.Types.Analysis
                 {
                     try
                     {
+                        ThreadContext.Properties["Meter"] = task.Meter.AssetKey;
                         Process(task);
                         taskProcessor.Dequeue(task);
                         _ = NotifyEventEmailNodeWhenIdle();

--- a/Source/Libraries/openXDA.Nodes/Types/Email/EventEmailProcessor.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/Email/EventEmailProcessor.cs
@@ -179,6 +179,8 @@ namespace openXDA.Nodes.Types.Email
 
             using (AdoDataConnection connection = ConnectionFactory())
             {
+                if (string.IsNullOrEmpty(m_emailModel.TriggerEmailSQL))
+                    return false;
                 return connection.ExecuteScalar<bool>(m_emailModel.TriggerEmailSQL, evt.ID);
             }
         }


### PR DESCRIPTION
Fixes DailyStatistics generation and added a `NULL` check when adding APP Trigger points in case there is no corresponding point on wave channel. 

There may be additional items to be fixed once we have ore logs. 