### PR TITLE
Xda 60

### DIFF
--- a/Source/Data/05 - DefaultSettings.sql
+++ b/Source/Data/05 - DefaultSettings.sql
@@ -236,6 +236,9 @@ GO
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('FaultLocation.UseDefaultFaultDetectionLogic', 'True', 'True')
 GO
 
+INSERT INTO Setting(Name, Value, DefaultValue) VALUES('FaultLocation.IgnoreFaultDetectionLogic', 'False', 'False')
+GO
+
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('FaultLocation.WarnMissingDetectionLogic', 'False', 'False')
 GO
 
@@ -387,9 +390,6 @@ INSERT INTO Setting(Name, Value, DefaultValue) VALUES('TaskProcessor.MeterFilter
 GO
 
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('TaskProcessor.ProcessingThreadCount', '0', '0')
-GO
-
-INSERT INTO Setting(Name, Value, DefaultValue) VALUES('UseDefaultFaultDetectionLogic', '1', '1')
 GO
 
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('WorkbenchTimeRangeInSeconds', '60', '60')

--- a/Source/Libraries/FaultData/DataResources/EventClassificationResource.cs
+++ b/Source/Libraries/FaultData/DataResources/EventClassificationResource.cs
@@ -122,10 +122,10 @@ namespace FaultData.DataResources
 
             if ((object)faultGroup != null)
             {
-                if (faultGroup.FaultDetectionLogicResult ?? false)
+                if ((faultGroup.FaultDetectionLogicResult ?? false) && !FaultLocationSettings.IgnoreFaultDetectionLogic)
                     return EventClassification.Fault;
 
-                if (!faultGroup.FaultDetectionLogicResult.HasValue && FaultLocationSettings.UseDefaultFaultDetectionLogic)
+                if ((!faultGroup.FaultDetectionLogicResult.HasValue || FaultLocationSettings.IgnoreFaultDetectionLogic) && FaultLocationSettings.UseDefaultFaultDetectionLogic)
                 {
                     if (faultGroup.FaultValidationLogicResult && faultGroup.Faults.Any(fault => !fault.IsSuppressed && !fault.IsReclose))
                         return EventClassification.Fault;

--- a/Source/Libraries/openXDA.Configuration/FaultLocationSection.cs
+++ b/Source/Libraries/openXDA.Configuration/FaultLocationSection.cs
@@ -84,6 +84,13 @@ namespace openXDA.Configuration
         [DefaultValue(true)]
         public bool UseDefaultFaultDetectionLogic { get; set; }
 
+        /// <summary>
+        /// Indicates whether to ignore line-specific fault detection logic.
+        /// </summary>
+        [Setting]
+        [DefaultValue(false)]
+        public bool IgnoreFaultDetectionLogic { get; set; }
+
         [Setting]
         [DefaultValue(0.8D)]
         public double FaultedVoltageThreshold { get; set; }


### PR DESCRIPTION
Covers this [PR](https://gridprotectionalliance.atlassian.net/browse/XDA-60)

The rational is that sometimes the line loader logic is not desired for fault detection, but if the logic doesn't fail completely it still gets used. 