### PR TITLE
Migration of controllers from SC to that custom logic may be used elsewhere

### DIFF
--- a/Source/Libraries/openXDA.Model/SEBrowser/TrendChannel.cs
+++ b/Source/Libraries/openXDA.Model/SEBrowser/TrendChannel.cs
@@ -1,0 +1,72 @@
+﻿//******************************************************************************************************
+//  TrendChannel.cs - Gbtc
+//
+//  Copyright © 2020, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  07/31/2025 - G. Santos
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using GSF.Data.Model;
+
+namespace SEBrowser.Model
+{
+    [TableName("Channel"),
+    CustomView(@"
+        SELECT
+	        DISTINCT Channel.ID,
+	        Channel.Name,
+	        Channel.Description,
+            Asset.ID as AssetID,
+	        Asset.AssetKey,
+	        Asset.AssetName,
+            Meter.ID as MeterID,
+	        Meter.AssetKey AS MeterKey,
+	        Meter.Name AS MeterName,
+            Meter.ShortName AS MeterShortName,
+	        Phase.Name AS Phase,
+	        ChannelGroup.Name AS ChannelGroup,
+	        ChannelGroupType.DisplayName AS ChannelGroupType,
+	        ChannelGroupType.Unit
+        FROM 
+	        Channel LEFT JOIN
+	        Phase ON Channel.PhaseID = Phase.ID LEFT JOIN
+	        Asset ON Asset.ID = Channel.AssetID LEFT JOIN
+	        Meter ON Meter.ID = Channel.MeterID LEFT JOIN
+	        ChannelGroupType ON Channel.MeasurementCharacteristicID = ChannelGroupType.MeasurementCharacteristicID AND Channel.MeasurementTypeID = ChannelGroupType.MeasurementTypeID LEFT JOIN
+	        ChannelGroup ON ChannelGroup.ID = ChannelGroupType.ChannelGroupID
+    "), AllowSearch]
+    public class TrendChannel
+    {
+        [PrimaryKey(true)]
+        public int ID { get; set; }
+        [DefaultSortOrder]
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public int AssetID { get; set; }
+        public string AssetKey { get; set; }
+        public string AssetName { get; set; }
+        public int MeterID { get; set; }
+        public string MeterKey { get; set; }
+        public string MeterName { get; set; }
+        public string MeterShortName { get; set; }
+        public string Phase { get; set; }
+        public string ChannelGroup { get; set; }
+        public string ChannelGroupType { get; set; }
+        public string Unit { get; set; }
+    }
+}

--- a/Source/Libraries/openXDA.Model/SystemCenter/ValueList.cs
+++ b/Source/Libraries/openXDA.Model/SystemCenter/ValueList.cs
@@ -21,8 +21,14 @@
 //
 //******************************************************************************************************
 
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+using System;
 using GSF.ComponentModel.DataAnnotations;
+using GSF.Data;
 using GSF.Data.Model;
+using GSF.Web.Model;
 
 namespace SystemCenter.Model
 {
@@ -43,5 +49,165 @@ namespace SystemCenter.Model
         public string AltValue { get; set; }
         public int SortOrder { get; set; }
 
+    }
+
+    public class ValueListController<T> : ModelController<T, ValueList>
+        where T : ValueList, new()
+    {
+        [HttpGet, Route("Group/{groupName}")]
+        public IHttpActionResult GetValueListForGroup(string groupName)
+        {
+            using (AdoDataConnection connection = new AdoDataConnection(Connection))
+            {
+                TableOperations<ValueListGroup> groupTable = new TableOperations<ValueListGroup>(connection);
+                TableOperations<ValueList> valueTable = new TableOperations<ValueList>(connection);
+                List<int> groupIds = groupTable.QueryRecordsWhere("Name = {0}", groupName).Select(group => group.ID).ToList();
+                if (groupIds.Count() == 0)
+                {
+                    RestrictedValueList restriction = RestrictedValueList.List.Find((g) => g.Name == groupName);
+                    if (!(restriction is null))
+                    {
+                        groupTable.AddNewRecord(
+                            new ValueListGroup()
+                            {
+                                Description = "",
+                                Name = restriction.Name
+                            });
+                        groupIds.Add(connection.ExecuteScalar<int>("SELECT @@IDENTITY"));
+
+                        int sortOrder = 1;
+                        foreach (object item in restriction.DefaultItems)
+                        {
+                            string value;
+                            string altValue;
+                            if (item.GetType() == typeof(Tuple<string, string>))
+                            {
+                                value = ((Tuple<string, string>)item).Item1;
+                                altValue = ((Tuple<string, string>)item).Item1;
+                            }
+                            else if (item.GetType() == typeof(string))
+                            {
+                                value = (string)item;
+                                altValue = (string)item;
+                            }
+                            else
+                                throw new InvalidCastException($"Could not convert object in DefaultItems of value list {restriction.Name} to either tuple or string.");
+                            valueTable.AddNewRecord(
+                                new ValueList()
+                                {
+                                    GroupID = groupIds[0],
+                                    Value = value,
+                                    AltValue = altValue,
+                                    SortOrder = sortOrder
+                                });
+                            sortOrder++;
+                        }
+                    }
+                    else
+                        return Ok(new List<ValueList>());
+                }
+                IEnumerable<ValueList> records = valueTable.QueryRecordsWhere("GroupID in ({0})", string.Join(", ", groupIds)).OrderBy(v => v.SortOrder);
+                return Ok(records);
+            }
+        }
+
+        public override IHttpActionResult Patch([FromBody] ValueList newRecord)
+        {
+            if (!PatchAuthCheck())
+            {
+                return Unauthorized();
+            }
+
+            // Check if Value changed
+            bool changeVal = false;
+            ValueList oldRecord;
+
+            using (AdoDataConnection connection = new AdoDataConnection(Connection))
+            {
+                oldRecord = new TableOperations<ValueList>(connection).QueryRecordWhere("ID = {0}", newRecord.ID);
+                changeVal = !(newRecord.Value == oldRecord.Value);
+            }
+
+            if (changeVal)
+            {
+                ValueListGroup group;
+                using (AdoDataConnection connection = new AdoDataConnection(Connection))
+                {
+                    group = new TableOperations<ValueListGroup>(connection).QueryRecordWhere("ID = {0}", newRecord.GroupID);
+                    // Wrapping is needed here, since C# tries to use the wrong method signature otherwise
+                    object[] parameters = new object[] { newRecord.Value, oldRecord.Value, group.Name };
+                    // Update Additional Fields
+                    connection.ExecuteScalar(@"UPDATE 
+                        AdditionalFieldValue
+                        SET [Value] = {0} 
+                        WHERE
+                        [Value] = {1} AND
+                        (
+                            SELECT TOP 1 Type
+                            FROM AdditionalField 
+                            WHERE AdditionalField.ID = AdditionalFieldValue.AdditionalFieldID
+                        ) = {2}", parameters);
+
+                    RestrictedValueList restriction = RestrictedValueList.List.Find((g) => g.Name == group.Name);
+                    if (!(restriction?.UpdateSQL is null))
+                    {
+                        object[] updateSqlParams = new object[] { newRecord.Value, oldRecord.Value };
+                        connection.ExecuteScalar(restriction.UpdateSQL, updateSqlParams);
+                    }
+                }
+            }
+            return base.Patch(newRecord);
+
+        }
+
+        public override IHttpActionResult Delete(ValueList record)
+        {
+            if (!DeleteAuthCheck())
+            {
+                return Unauthorized();
+            }
+
+            ValueListGroup group;
+            using (AdoDataConnection connection = new AdoDataConnection(Connection))
+            {
+                group = new TableOperations<ValueListGroup>(connection).QueryRecordWhere("ID = {0}", record.GroupID);
+                RestrictedValueList restriction = RestrictedValueList.List.Find((g) => g.Name == group.Name);
+                if (!(restriction?.CountSQL is null))
+                {
+                    int count = connection.ExecuteScalar<int>(restriction.CountSQL, record.Value);
+                    if (count > 0)
+                        return Unauthorized();
+                }
+
+                connection.ExecuteScalar(@"DELETE FROM AdditionalFieldValue
+                            WHERE
+                            [Value] = {0} AND
+                            (SELECT TOP 1 Type FROM AdditionalField AF WHERE AF.ID = AdditionalFieldValue.AdditionalFieldID) = {1}", (object)record.Value, group.Name);
+
+                return base.Delete(record);
+            }
+
+        }
+
+        [Route("Count/{groupName}/{value}"), HttpGet]
+        public IHttpActionResult GetCount(string groupName, string value)
+        {
+            if (!PatchAuthCheck())
+                return Unauthorized();
+            using (AdoDataConnection connection = new AdoDataConnection(Connection))
+            {
+                int nAddlFields = connection.ExecuteScalar<int>(@"SELECT COUNT(AFV.ID) FROM AdditionalFieldValue AFV WHERE 
+                        [Value] = {0} AND (SELECT TOP 1 AF.ID FROM AdditionalField AF WHERE Type = {1}) = AFV.AdditionalFieldID
+                        ", value, groupName);
+                RestrictedValueList restriction = RestrictedValueList.List.Find((g) => g.Name == groupName);
+                int count = 0;
+                if (!(restriction?.CountSQL is null))
+                {
+                    count = connection.ExecuteScalar<int>(restriction.CountSQL, value);
+                }
+                return Ok(nAddlFields + count);
+            }
+
+        }
     }
 }

--- a/Source/Libraries/openXDA.Model/SystemCenter/ValueListGroup.cs
+++ b/Source/Libraries/openXDA.Model/SystemCenter/ValueListGroup.cs
@@ -129,29 +129,28 @@ namespace SystemCenter.Model
              new RestrictedValueList() {
                 Name = "TrendLabelDefaults",
                 DefaultItems = new Tuple<string, string>[] {
-                    new Tuple<string, string>("MeterName", "Meter Name"),
-                    new Tuple<string, string>("AssetKey", "Asset Key"),
-                    new Tuple<string, string>("Name", "Channel Label"),
-                    new Tuple<string, string>("ChannelGroup", "Channel Group Name"),
-                    new Tuple<string, string>("MinMaxAvg_Special", "Channel Series")
+                    new Tuple<string, string>("Channel.MeterName", "Meter Name"),
+                    new Tuple<string, string>("Channel.AssetKey", "Asset Key"),
+                    new Tuple<string, string>("Channel.Name", "Channel Label"),
+                    new Tuple<string, string>("Channel.ChannelGroup", "Channel Group Name"),
+                    new Tuple<string, string>("Channel.MinMaxAvg_Special", "Channel Series")
                 }
             },
              new RestrictedValueList() {
                 Name = "TrendLabelOptions",
                 DefaultItems = new Tuple<string, string>[] {
-                    new Tuple<string, string>("MeterName", "Meter Name"),
-                    new Tuple<string, string>("MeterShortName", "Meter Short Name"),
-                    new Tuple<string, string>("MeterKey", "Meter Asset Key"),
-                    new Tuple<string, string>("AssetName", "Asset Name"),
-                    new Tuple<string, string>("AssetKey", "Asset Key"),
-                    new Tuple<string, string>("Phase", "Phase Name"),
-                    new Tuple<string, string>("Name", "Channel Label"),
-                    new Tuple<string, string>("Description", "Channel Description"),
-                    new Tuple<string, string>("ChannelGroup", "Channel Group Name"),
-                    new Tuple<string, string>("ChannelGroupType", "Channel Group Type"),
-                    // This is not a field, special case: represents min max or avg/values out of HIDS
-                    new Tuple<string, string>("MinMaxAvg_Special", "Channel Series"),
-                    new Tuple<string, string>("Unit", "Unit")
+                    new Tuple<string, string>("Channel.MeterName", "Meter Name"),
+                    new Tuple<string, string>("Channel.MeterShortName", "Meter Short Name"),
+                    new Tuple<string, string>("Channel.MeterKey", "Meter Asset Key"),
+                    new Tuple<string, string>("Channel.AssetName", "Asset Name"),
+                    new Tuple<string, string>("Channel.AssetKey", "Asset Key"),
+                    new Tuple<string, string>("Channel.Phase", "Phase Name"),
+                    new Tuple<string, string>("Channel.Name", "Channel Label"),
+                    new Tuple<string, string>("Channel.Description", "Channel Description"),
+                    new Tuple<string, string>("Channel.ChannelGroup", "Channel Group Name"),
+                    new Tuple<string, string>("Channel.ChannelGroupType", "Channel Group Type"),
+                    new Tuple<string, string>("Series.SeriesType", "Channel Series"),
+                    new Tuple<string, string>("Channel.Unit", "Unit")
                 }
             }
         };

--- a/Source/Libraries/openXDA.Model/SystemCenter/ValueListGroup.cs
+++ b/Source/Libraries/openXDA.Model/SystemCenter/ValueListGroup.cs
@@ -22,9 +22,13 @@
 //******************************************************************************************************
 
 using GSF.ComponentModel.DataAnnotations;
+using GSF.Data;
 using GSF.Data.Model;
+using GSF.Web.Model;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Web.Http;
 
 namespace SystemCenter.Model
 {
@@ -41,5 +45,175 @@ namespace SystemCenter.Model
         [StringLength(200)]
         public string Name { get; set; }
         public string Description { get; set; }
+    }
+
+    public class RestrictedValueList
+    {
+        public string Name { get; set; }
+        public string CountSQL { get; set; }
+        public string UpdateSQL { get; set; }
+
+        /// <summary>
+        /// Default items in a <see cref="RestrictedValueList"/>.
+        /// Objects may be either <see langword="string"/> or <see cref="Tuple"/> of two <see langword="string"/>,
+        /// where the <see cref="Tuple"/> represents &lt;<see cref="ValueList.Value"/>, <see cref="ValueList.AltValue"/>&gt;
+        /// </summary>
+        public object[] DefaultItems { get; set; }
+
+        public static List<RestrictedValueList> List = new List<RestrictedValueList>(){
+            new RestrictedValueList() {
+                Name = "TimeZones",
+                CountSQL = @"SELECT COUNT(ID) FROM 
+                        Meter
+                        WHERE [TimeZone] = {0}",
+                UpdateSQL = @"UPDATE Meter
+                            SET [TimeZone] = {0} 
+                        WHERE
+                            [TimeZone] = {1}",
+                DefaultItems = new string[] {"UTC"}
+            },
+             new RestrictedValueList() {
+                Name = "Make",
+                CountSQL = @"SELECT COUNT(ID) FROM 
+                        Meter
+                        WHERE [Make] = {0}",
+                UpdateSQL = @"UPDATE 
+                        Meter
+                        SET [Make] = {0} 
+                        WHERE
+                        [Make] = {1}",
+                DefaultItems = new string[] {"GPA"}
+            },
+             new RestrictedValueList() {
+                Name = "Model",
+                CountSQL = @"SELECT COUNT(ID) FROM 
+                        Meter
+                        WHERE [Model] = {0}",
+                UpdateSQL = @"UPDATE 
+                        Meter
+                        SET [Model] = {0} 
+                        WHERE
+                        [Model] = {1}",
+                DefaultItems = new string[] {"PQMeter"}
+            },
+             new RestrictedValueList() {
+                Name = "Unit",
+                CountSQL = @"SELECT COUNT(ID) FROM  
+                        ChannelGroupType
+                        WHERE
+                        [Unit] = {0}",
+                UpdateSQL = @"UPDATE 
+                        ChannelGroupType
+                        SET [Unit] = {0} 
+                        WHERE
+                        [Unit] = {1}",
+                DefaultItems = new string[] {"Unknown"}
+            },
+             new RestrictedValueList() {
+                Name = "Category",
+                CountSQL = @"SELECT COUNT(ID) FROM  
+                        LocationDrawing
+                        WHERE
+                        [Category] = {0}",
+                UpdateSQL = @"UPDATE 
+                        LocationDrawing
+                        SET [Category] = {0} 
+                        WHERE
+                        [Category] = {1}",
+                DefaultItems = new string[] {"Oneline"}
+            },
+             new RestrictedValueList() {
+                Name = "SpareChannel",
+                DefaultItems = new string[] {"Spare Channel"}
+            },
+             new RestrictedValueList() {
+                Name = "TrendLabelDefaults",
+                DefaultItems = new Tuple<string, string>[] {
+                    new Tuple<string, string>("MeterName", "Meter Name"),
+                    new Tuple<string, string>("AssetKey", "Asset Key"),
+                    new Tuple<string, string>("Name", "Channel Label"),
+                    new Tuple<string, string>("ChannelGroup", "Channel Group Name"),
+                    new Tuple<string, string>("MinMaxAvg_Special", "Channel Series")
+                }
+            },
+             new RestrictedValueList() {
+                Name = "TrendLabelOptions",
+                DefaultItems = new Tuple<string, string>[] {
+                    new Tuple<string, string>("MeterName", "Meter Name"),
+                    new Tuple<string, string>("MeterShortName", "Meter Short Name"),
+                    new Tuple<string, string>("MeterKey", "Meter Asset Key"),
+                    new Tuple<string, string>("AssetName", "Asset Name"),
+                    new Tuple<string, string>("AssetKey", "Asset Key"),
+                    new Tuple<string, string>("Phase", "Phase Name"),
+                    new Tuple<string, string>("Name", "Channel Label"),
+                    new Tuple<string, string>("Description", "Channel Description"),
+                    new Tuple<string, string>("ChannelGroup", "Channel Group Name"),
+                    new Tuple<string, string>("ChannelGroupType", "Channel Group Type"),
+                    // This is not a field, special case: represents min max or avg/values out of HIDS
+                    new Tuple<string, string>("MinMaxAvg_Special", "Channel Series"),
+                    new Tuple<string, string>("Unit", "Unit")
+                }
+            }
+        };
+    }
+
+    public class ValueListGroupController<T> : ModelController<T, ValueListGroup> 
+        where T : ValueListGroup, new()
+    {
+        public override IHttpActionResult Patch([FromBody] ValueListGroup newRecord)
+        {
+            if (!PatchAuthCheck())
+            {
+                return Unauthorized();
+            }
+
+            // Check if Value changed
+            bool changeVal = false;
+            ValueListGroup oldRecord;
+
+            using (AdoDataConnection connection = new AdoDataConnection(Connection))
+            {
+                oldRecord = new TableOperations<ValueListGroup>(connection).QueryRecordWhere("ID = {0}", newRecord.ID);
+                changeVal = !(newRecord.Name == oldRecord.Name);
+            }
+
+            if (changeVal)
+            {
+                using (AdoDataConnection connection = new AdoDataConnection(Connection))
+                {
+                    // Wrapping is needed here, since C# tries to use the wrong method signature otherwise
+                    object[] parameters = new object[] { newRecord.Name, oldRecord.Name };
+                    // Update Additional Fields
+                    connection.ExecuteScalar(@"UPDATE 
+                        AdditionalField
+                        SET [Type] = {0} 
+                        WHERE
+                        [Type] = {1}", parameters);
+                }
+            }
+            return base.Patch(newRecord);
+
+        }
+
+        public override IHttpActionResult Delete(ValueListGroup record)
+        {
+            if (!DeleteAuthCheck())
+            {
+                return Unauthorized();
+            }
+
+            using (AdoDataConnection connection = new AdoDataConnection(Connection))
+            {
+                // Wrapping is needed here, since C# tries to use the wrong method signature otherwise
+                object[] parameters = new object[] { record.Name };
+                // Update Additional Fields
+                connection.ExecuteScalar(@"UPDATE 
+                    AdditionalField
+                    SET [Type] = 'string' 
+                    WHERE
+                    [Type] = {0}", parameters);
+            }
+            return base.Delete(record);
+        }
     }
 }

--- a/Source/Libraries/openXDA.Model/openXDA.Model.csproj
+++ b/Source/Libraries/openXDA.Model/openXDA.Model.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Nodes\NodeSetting.cs" />
     <Compile Include="Note.cs" />
     <Compile Include="SEBrowser\D3DataSeries.cs" />
+    <Compile Include="SEBrowser\TrendChannel.cs" />
     <Compile Include="SEBrowser\Widget.cs" />
     <Compile Include="SEBrowser\WidgetCategory.cs" />
     <Compile Include="SEBrowser\WidgetWidgetCategory.cs" />


### PR DESCRIPTION
Cover's the following pieces: [SC-147](https://gridprotectionalliance.atlassian.net/browse/SC-147) [SC-303](https://gridprotectionalliance.atlassian.net/browse/SC-303)

Moved this because the logic for adding default items would be side-stepped in PQBrowser with the current setup.
Also fixes some issues with value list deletion and editing, as well as introduces two new default items and the ability to specify default value and alt values.

Required by [SC PR 738](https://github.com/GridProtectionAlliance/SystemCenter/pull/738)

[SC-147]: https://gridprotectionalliance.atlassian.net/browse/SC-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SC-303]: https://gridprotectionalliance.atlassian.net/browse/SC-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ