### PR TITLE
Use case-insensitive comparisons for channel/series keys

### DIFF
--- a/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
@@ -695,7 +695,7 @@ namespace FaultData.DataOperations
                     }, grouping => grouping.First());
 
                 List<Series> undefinedSeries = undefinedDataSeries
-                    .SelectMany(dataSeries => dataSeries.SeriesInfo.Channel.Series)
+                    .Select(dataSeries => dataSeries.SeriesInfo)
                     .GroupBy(series => new SeriesKey(series))
                     .Where(grouping => !seriesLookup.ContainsKey(grouping.Key))
                     .Select(grouping => grouping.First())

--- a/Source/Libraries/FaultData/DataReaders/PQDIFReader.cs
+++ b/Source/Libraries/FaultData/DataReaders/PQDIFReader.cs
@@ -374,7 +374,6 @@ namespace FaultData.DataReaders
             channel.Phase = new openXDA.Model.Phase();
             channel.Name = channelDefinition.ChannelName;
             channel.HarmonicGroup = 0;
-            channel.Series.Add(series);
 
             if (seriesDefinition.HasElement(SeriesDefinition.SeriesNominalQuantityTag))
                 channel.PerUnitValue = seriesDefinition.SeriesNominalQuantity;

--- a/Source/Libraries/openXDA.Model/Channels/Channel.cs
+++ b/Source/Libraries/openXDA.Model/Channels/Channel.cs
@@ -110,13 +110,15 @@ namespace openXDA.Model
 
         public override int GetHashCode()
         {
+            StringComparer stringComparer = StringComparer.OrdinalIgnoreCase;
+
             int hash = 1009;
             hash = 9176 * hash + LineID.GetHashCode();
             hash = 9176 * hash + HarmonicGroup.GetHashCode();
-            hash = 9176 * hash + Name.GetHashCode();
-            hash = 9176 * hash + MeasurementType.GetHashCode();
-            hash = 9176 * hash + MeasurementCharacteristic.GetHashCode();
-            hash = 9176 * hash + Phase.GetHashCode();
+            hash = 9176 * hash + stringComparer.GetHashCode(Name);
+            hash = 9176 * hash + stringComparer.GetHashCode(MeasurementType);
+            hash = 9176 * hash + stringComparer.GetHashCode(MeasurementCharacteristic);
+            hash = 9176 * hash + stringComparer.GetHashCode(Phase);
             return hash;
         }
 
@@ -130,13 +132,15 @@ namespace openXDA.Model
             if (other is null)
                 return false;
 
+            StringComparison stringComparison = StringComparison.OrdinalIgnoreCase;
+
             return
                 LineID.Equals(other.LineID) &&
                 HarmonicGroup.Equals(other.HarmonicGroup) &&
-                Name.Equals(other.Name) &&
-                MeasurementType.Equals(other.MeasurementType) &&
-                MeasurementCharacteristic.Equals(other.MeasurementCharacteristic) &&
-                Phase.Equals(other.Phase);
+                Name.Equals(other.Name, stringComparison) &&
+                MeasurementType.Equals(other.MeasurementType, stringComparison) &&
+                MeasurementCharacteristic.Equals(other.MeasurementCharacteristic, stringComparison) &&
+                Phase.Equals(other.Phase, stringComparison);
         }
 
         #endregion

--- a/Source/Libraries/openXDA.Model/Channels/Series.cs
+++ b/Source/Libraries/openXDA.Model/Channels/Series.cs
@@ -22,9 +22,7 @@
 //******************************************************************************************************
 
 using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using GSF.Data;
 using GSF.Data.Model;
 using Newtonsoft.Json;
@@ -102,9 +100,11 @@ namespace openXDA.Model
 
         public override int GetHashCode()
         {
+            StringComparer stringComparer = StringComparer.OrdinalIgnoreCase;
+
             int hash = 1009;
             hash = 9176 * hash + ChannelKey.GetHashCode();
-            hash = 9176 * hash + SeriesType.GetHashCode();
+            hash = 9176 * hash + stringComparer.GetHashCode(SeriesType);
             return hash;
         }
 
@@ -118,9 +118,11 @@ namespace openXDA.Model
             if (other is null)
                 return false;
 
+            StringComparison stringComparison = StringComparison.OrdinalIgnoreCase;
+
             return
                 ChannelKey.Equals(other.ChannelKey) &&
-                SeriesType.Equals(other.SeriesType);
+                SeriesType.Equals(other.SeriesType, stringComparison);
         }
 
         #endregion


### PR DESCRIPTION
This PR is pretty self-explanatory, but I also fixed a couple issues I noticed during the code review.

* `PQDIFReader` was adding the series to the channel's list of series twice.
  * Line 371: `channel.Series = new List<Series>() { series };`
  * Line 377: `channel.Series.Add(series);`
* `AddUndefinedChannels()` was using `SelectMany()` to flatten the series list from the channel associated with the series. At best, this is pointless compared to just using the series without dereferencing the channel at all. At worst, the `IDataReader` implementation _technically_ could skip adding the series to the channel's series list. Most importantly, though, it's conceptually incorrect and therefore inconsistent with `ConfigurationOperation` line 734, where we simply use `dataSeries.SeriesInfo` instead of `dataSeries.SeriesInfo.Channel.Series.ForEach(...)`.