### PR TITLE
Addition of Digitals to Data Group Resource

### DIFF
--- a/Source/Libraries/FaultData/DataResources/DataGroupsResource.cs
+++ b/Source/Libraries/FaultData/DataResources/DataGroupsResource.cs
@@ -58,7 +58,7 @@ namespace FaultData.DataResources
         {
             List<DataGroup> dataGroups = new List<DataGroup>();
 
-            foreach (IGrouping<DataGroupKey, DataSeries> dataGrouping in meterDataSet.DataSeries.GroupBy(GetKey))
+            foreach (IGrouping<DataGroupKey, DataSeries> dataGrouping in meterDataSet.DataSeries.Concat(meterDataSet.Digitals).GroupBy(GetKey))
             {
                 HashSet<int> completedAsset = new HashSet<int>();
 


### PR DESCRIPTION
Not having this was causing Event Classification resource to not be able to use Custom Fault Detection logic.

[XDA-60](https://gridprotectionalliance.atlassian.net/browse/XDA-60)

[XDA-60]: https://gridprotectionalliance.atlassian.net/browse/XDA-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ