### PR TITLE
XDA-56 Fix errors in connected channel traversal

### DIFF
--- a/Source/Libraries/openXDA.Model/Meters/Location.cs
+++ b/Source/Libraries/openXDA.Model/Meters/Location.cs
@@ -237,6 +237,7 @@ namespace openXDA.Model
                     Asset asset = assetTable.QueryRecordWhere("ID = {0}", assetID);
                     asset = LazyContext.GetAsset(asset);
                     asset.ConnectedChannels = connectedChannels.ToList();
+                    asset.LazyContext = LazyContext;
                 }
             }
         }
@@ -346,8 +347,10 @@ namespace openXDA.Model
             {
                 foreach (DataRow row in table.AsEnumerable())
                 {
-                    Channel channel = channelTable.LoadRecord(row);
-                    yield return LazyContext.GetChannel(channel);
+                    Channel loadedChannel = channelTable.LoadRecord(row);
+                    Channel lookedUpChannel = LazyContext.GetChannel(loadedChannel);
+                    lookedUpChannel.LazyContext = LazyContext;
+                    yield return lookedUpChannel;
                 }
             }
 

--- a/Source/Libraries/openXDA.Model/Meters/Location.cs
+++ b/Source/Libraries/openXDA.Model/Meters/Location.cs
@@ -240,6 +240,10 @@ namespace openXDA.Model
                     asset.LazyContext = LazyContext;
                 }
             }
+
+            // Assign empty lists to any assets that were missed by the recursive search
+            foreach (Asset asset in AssetLocations.Select(al => al.Asset))
+                EnsureConnectedChannels(asset);
         }
 
         private void TraverseAssetConnections(AdoDataConnection connection, ChannelConnector connectChannels)
@@ -411,6 +415,23 @@ namespace openXDA.Model
                 HashSet<Channel> connectedChannels = connectedChannelLookup.GetOrAdd(assetID, _ => new HashSet<Channel>());
                 connectedChannels.UnionWith(channels);
             };
+        }
+
+        private static void EnsureConnectedChannels(Asset asset)
+        {
+            Func<AdoDataConnection> connectionFactory = asset.ConnectionFactory;
+
+            try
+            {
+                asset.ConnectionFactory = null;
+
+                if (asset.ConnectedChannels is null)
+                    asset.ConnectedChannels = new List<Channel>();
+            }
+            finally
+            {
+                asset.ConnectionFactory = connectionFactory;
+            }
         }
 
         #endregion

--- a/Source/Libraries/openXDA.Model/TransmissionElements/Asset.cs
+++ b/Source/Libraries/openXDA.Model/TransmissionElements/Asset.cs
@@ -553,7 +553,7 @@ namespace openXDA.Model
         private static ConnectedChannelLookup GetConnectedChannelLookup(AdoDataConnection connection, int locationID)
         {
             const string ChannelQueryFormat =
-                "SELECT Channel.* " +
+                "SELECT SourceChannel.* " +
                 "FROM " +
                 "    Channel SourceChannel JOIN " +
                 "    Meter ON " +

--- a/Source/Libraries/openXDA.Model/TransmissionElements/Asset.cs
+++ b/Source/Libraries/openXDA.Model/TransmissionElements/Asset.cs
@@ -178,15 +178,10 @@ namespace openXDA.Model
 
         [JsonIgnore]
         [NonRecordField]
-        public List<Asset> ConnectedAssets
-        {
-            get
-            {
-                return Connections.Where(item => item.ChildID == ID).Select(item => item.Parent).Concat(
-                    Connections.Where(item => item.ParentID == ID).Select(item => item.Child)).ToList();
-            }
-            
-        }
+        public List<Asset> ConnectedAssets => Connections?
+            .SelectMany(connection => new[] { connection.Parent, connection.Child })
+            .Where(asset => asset.ID != ID)
+            .ToList();
 
         [JsonIgnore]
         [NonRecordField]

--- a/Source/Libraries/openXDA.Model/TransmissionElements/Asset.cs
+++ b/Source/Libraries/openXDA.Model/TransmissionElements/Asset.cs
@@ -360,6 +360,9 @@ namespace openXDA.Model
         // Logic for Channels across Asset Connections
         public IEnumerable<Channel> GetConnectedChannels(AdoDataConnection connection)
         {
+            if (connection is null)
+                return null;
+
             return AssetLocations
                 .SelectMany(assetLocation => TraverseConnectedChannels(connection, assetLocation.LocationID, ID))
                 .Distinct(new ChannelComparer());


### PR DESCRIPTION
The following error occurs because `Location.ConnectAllChannels()` doesn't assign the `LazyContext` to the asset records it pulls from the database. This PR makes sure `LazyContext` is assigned to those assets as well as the connected channels we query throughout the traversal. It also fixes the error in `Asset.ConnectedAssets` by simply returning null if `Connections` returns null.

```
An error occurred while executing data operation of type 'FaultData.DataOperations.StatisticOperation' on data from meter '...': Value cannot be null.
Parameter name: source
    at System.Linq.Enumerable.Where[TSource](IEnumerable`1 source, Func`2 predicate)
    at openXDA.Model.Asset.get_ConnectedAssets()
    at System.Linq.Enumerable.<SelectManyIterator>d__17`2.MoveNext()
    at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
    at System.Linq.Enumerable.<DistinctIterator>d__64`1.MoveNext()
    at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
    at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
    at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
    at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
    at openXDA.Model.Asset.DistanceToAsset(Int32 assetID)
    at FaultData.DataAnalysis.VIDataGroup..ctor(DataGroup dataGroup)
    at FaultData.DataResources.CycleDataResource.<>c.<Initialize>b__17_3(DataGroup dataGroup)
    at System.Linq.Enumerable.WhereSelectListIterator`2.MoveNext()
    at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
    at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
    at FaultData.DataResources.CycleDataResource.Initialize(MeterDataSet meterDataSet)
    at FaultData.DataResources.DataResourceBase`1.Initialize(IDataSet dataSet)
    at FaultData.DataSets.MeterDataSet.GetResource[T](Func`1 resourceFactory)
    at FaultData.DataOperations.EventOperation.Execute(MeterDataSet meterDataSet)
    at FaultData.DataOperations.DataOperationBase`1.Execute(IDataSet dataSet)
    at openXDA.Nodes.Types.Analysis.AnalysisNode.Process(MeterDataSet meterDataSet)
```

---

The following error occurs because the `Channel` table was aliased to `SourceChannel` in the query, but I referenced it by `Channel` in the `SELECT` clause. This PR resolves that error.

That said, this happens during forward traversal, which shouldn't even be happening since we used reverse traversal to connect all channels at the station. I suspect there must be some assets connected to the meter that, for whatever reason, do not have any channels connected to them directly or indirectly. As a result, they get skipped by the reverse traversal logic. This PR adds some logic to force the `ConnectedChannels` property to an empty list for all assets connected to the station via `AssetLocation`. We might still trigger forward traversal if `AssetLocation` and `MeterAsset` aren't properly synchronized.

```
An error occurred while executing data operation of type 'openXDA.HIDS.TrendingDataSummaryOperation' on data from meter '...': The column prefix 'Channel' does not match with a table name or alias name used in the query.
    at System.Data.SqlClient.SqlConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction)
    at System.Data.SqlClient.TdsParser.ThrowExceptionAndWarning(TdsParserStateObject stateObj, Boolean callerHasConnectionLock, Boolean asyncClose)
    at System.Data.SqlClient.TdsParser.TryRun(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj, Boolean& dataReady)
    at System.Data.SqlClient.SqlDataReader.TryConsumeMetaData()
    at System.Data.SqlClient.SqlDataReader.get_MetaData()
    at System.Data.SqlClient.SqlCommand.FinishExecuteReader(SqlDataReader ds, RunBehavior runBehavior, String resetOptionsString, Boolean isInternal, Boolean forDescribeParameterEncryption, Boolean shouldCacheForAlwaysEncrypted)
    at System.Data.SqlClient.SqlCommand.RunExecuteReaderTds(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, Boolean async, Int32 timeout, Task& task, Boolean asyncWrite, Boolean inRetry, SqlDataReader ds, Boolean describeParameterEncryptionRequest)
    at System.Data.SqlClient.SqlCommand.RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, String method, TaskCompletionSource`1 completion, Int32 timeout, Task& task, Boolean& usedCache, Boolean asyncWrite, Boolean inRetry)
    at System.Data.SqlClient.SqlCommand.RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, String method)
    at System.Data.SqlClient.SqlCommand.ExecuteReader(CommandBehavior behavior, String method)
    at System.Data.Common.DbDataAdapter.FillInternal(DataSet dataset, DataTable[] datatables, Int32 startRecord, Int32 maxRecords, String srcTable, IDbCommand command, CommandBehavior behavior)
    at System.Data.Common.DbDataAdapter.Fill(DataSet dataSet, Int32 startRecord, Int32 maxRecords, String srcTable, IDbCommand command, CommandBehavior behavior)
    at System.Data.Common.DbDataAdapter.Fill(DataSet dataSet)
    at GSF.Data.DataExtensions.RetrieveDataSet(IDbConnection connection, Type dataAdapterType, String sql, Int32 timeout, Object[] parameters)
    at GSF.Data.AdoDataConnection.RetrieveData(Int32 timeout, String sqlFormat, Object[] parameters)
    at openXDA.Model.Asset.<>c__DisplayClass77_0.<<GetConnectedChannelLookup>g__RetrieveRows|5>d.MoveNext()
    at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
    at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
    at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
    at GSF.Collections.CollectionExtensions.GetOrAdd[TKey,TValue](IDictionary`2 dictionary, TKey key, Func`2 valueFactory)
    at openXDA.Model.Asset.TraverseConnectedChannels(AdoDataConnection connection, Int32 locationID, Int32 assetID)
    at System.Linq.Enumerable.<SelectManyIterator>d__17`2.MoveNext()
    at System.Linq.Enumerable.<DistinctIterator>d__64`1.MoveNext()
    at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
    at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
    at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
    at openXDA.Model.Asset.QueryConnectedChannels()
    at openXDA.Model.Asset.get_ConnectedChannels()
    at FaultData.DataResources.DataGroupsResource.GetConnectedSeries(IEnumerable`1 groupedSeries, Asset asset)
    at FaultData.DataResources.DataGroupsResource.Initialize(MeterDataSet meterDataSet)
    at FaultData.DataResources.DataResourceBase`1.Initialize(IDataSet dataSet)
    at FaultData.DataSets.MeterDataSet.GetResource[T](Func`1 resourceFactory)
    at FaultData.DataResources.TrendingGroupsResource.Initialize(MeterDataSet meterDataSet)
    at FaultData.DataResources.DataResourceBase`1.Initialize(IDataSet dataSet)
    at FaultData.DataSets.MeterDataSet.GetResource[T](Func`1 resourceFactory)
    at openXDA.HIDS.TrendingDataSummaryOperation.Execute(MeterDataSet meterDataSet)
    at FaultData.DataOperations.DataOperationBase`1.Execute(IDataSet dataSet)
    at openXDA.Nodes.Types.Analysis.AnalysisNode.Process(MeterDataSet meterDataSet)
```