### PR TITLE
Convert DataPoint to a struct

### DIFF
--- a/Source/Libraries/FaultData/DataAnalysis/VoltageDisturbanceAnalyzer.cs
+++ b/Source/Libraries/FaultData/DataAnalysis/VoltageDisturbanceAnalyzer.cs
@@ -475,9 +475,12 @@ namespace FaultData.DataAnalysis
 
         private bool IsDisturbed(Disturbance disturbance)
         {
-            DataPoint dataPoint = new DataPoint();
-            dataPoint.Time = disturbance.StartTime;
-            dataPoint.Value = disturbance.PerUnitMagnitude;
+            DataPoint dataPoint = new()
+            {
+                Time = disturbance.StartTime,
+                Value = disturbance.PerUnitMagnitude
+            };
+
             return m_isDisturbed(dataPoint);
         }
 

--- a/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/ConfigurationOperation.cs
@@ -579,15 +579,9 @@ namespace FaultData.DataOperations
                 double adder = series.SeriesInfo.Channel.Adder;
                 double multiplier = series.SeriesInfo.Channel.Multiplier;
 
-                DataSeries adderSeries = series.Copy();
-
-                foreach (DataPoint point in adderSeries.DataPoints)
-                    point.Value = adder;
-
-                definedSeries[i] = series
-                    .Multiply(multiplier)
-                    .Add(adderSeries);
-                definedSeries[i].SeriesInfo = series.SeriesInfo;
+                DataSeries adjusted = series.ApplyLinearAdjustment(multiplier, adder);
+                adjusted.SeriesInfo = series.SeriesInfo;
+                definedSeries[i] = adjusted;
             }
         }
 

--- a/Source/Libraries/FaultData/DataOperations/DataRescueOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/DataRescueOperation.cs
@@ -85,8 +85,8 @@ namespace FaultData.DataOperations
 
                 foreach (DataSeries dataSeries in lookup[adjustment.ChannelID])
                 {
-                    foreach (DataPoint dataPoint in dataSeries.DataPoints)
-                        dataPoint.Value = dataPoint.Value * multiplier + adder;
+                    DataSeries adjusted = dataSeries.ApplyLinearAdjustment(multiplier, adder);
+                    dataSeries.DataPoints = adjusted.DataPoints;
                 }
             }
         }
@@ -98,14 +98,14 @@ namespace FaultData.DataOperations
 
             foreach (DataSeries dataSeries in meterDataSet.DataSeries)
             {
-                foreach (DataPoint dataPoint in dataSeries.DataPoints)
-                    dataPoint.Time += shift;
+                DataSeries shifted = dataSeries.Shift(shift);
+                dataSeries.DataPoints = shifted.DataPoints;
             }
 
             foreach (DataSeries dataSeries in meterDataSet.Digitals)
             {
-                foreach (DataPoint dataPoint in dataSeries.DataPoints)
-                    dataPoint.Time += shift;
+                DataSeries shifted = dataSeries.Shift(shift);
+                dataSeries.DataPoints = shifted.DataPoints;
             }
 
             for (int i = 0; i < meterDataSet.ReportedDisturbances.Count; i++)

--- a/Source/Libraries/FaultData/DataOperations/FaultLocationOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/FaultLocationOperation.cs
@@ -262,7 +262,11 @@ namespace FaultData.DataOperations
                     int endSample = startSample + fault.Curves.Min(curve => curve.Series.DataPoints.Count) - 1;
 
                     for (int sample = fault.StartSample; sample <= endSample; sample++)
-                        series[sample].Value = fault.Curves[curveIndex].Series[sample - fault.StartSample].Value;
+                    {
+                        int offset = sample - fault.StartSample;
+                        Fault.Curve curve = fault.Curves[curveIndex];
+                        series.DataPoints[sample] = curve.Series[offset];
+                    }
                 }
 
                 return new FaultCurve()

--- a/Source/Libraries/FaultData/DataOperations/StatisticOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/StatisticOperation.cs
@@ -169,13 +169,15 @@ namespace FaultData.DataOperations
 
         private double? CalcMax(DataSeries rms) => rms?.DataPoints
             .Where(dataPoint => !double.IsNaN(dataPoint.Value))
+            .Select(dataPoint => (double?)dataPoint.Value)
             .DefaultIfEmpty(null)
-            .Max(dataPoint => dataPoint?.Value);
+            .Max();
 
         private double? CalcMin(DataSeries rms) => rms?.DataPoints
             .Where(dataPoint => !double.IsNaN(dataPoint.Value))
+            .Select(dataPoint => (double?)dataPoint.Value)
             .DefaultIfEmpty(null)
-            .Min(dataPoint => dataPoint?.Value);
+            .Min();
 
         private double? CalcI2t(DataAnalysis.FaultGroup faultGroup, DataSeries waveform)
         {

--- a/Source/Libraries/FaultData/FaultData.csproj
+++ b/Source/Libraries/FaultData/FaultData.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Source/Libraries/openXDA.Adapters/openXDA.Adapters.csproj
+++ b/Source/Libraries/openXDA.Adapters/openXDA.Adapters.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Source/Libraries/openXDA.Model/Channels/ChannelData.cs
+++ b/Source/Libraries/openXDA.Model/Channels/ChannelData.cs
@@ -115,10 +115,10 @@ namespace openXDA.Model
                 return;
 
             Tuple<int, List<DataPoint>> decompressed = Decompress(TimeDomainData)[0];
-            List<DataPoint> data = decompressed.Item2;
 
-            foreach (DataPoint dataPoint in data)
-                dataPoint.Time = dataPoint.Time.AddTicks(ticks);
+            List<DataPoint> data = decompressed.Item2
+                .Select(point => point.Shift(ticks))
+                .ToList();
 
             TimeDomainData = ToData(data, decompressed.Item1);
         }

--- a/Source/Libraries/openXDA.Model/Channels/DataPoint.cs
+++ b/Source/Libraries/openXDA.Model/Channels/DataPoint.cs
@@ -28,84 +28,68 @@ namespace openXDA.Model
     /// <summary>
     /// Represents a single data point in a time series.
     /// </summary>
-    public class DataPoint
+    public readonly struct DataPoint
     {
         #region [ Properties ]
 
-        public DateTime Time { get; set; }
-        public double Value { get; set; }
+        public DateTime Time { get; init; }
+        public double Value { get; init; }
 
         #endregion
 
         #region [ Methods ]
 
-        public DataPoint Shift(TimeSpan timeShift)
+        public DataPoint NewTime(DateTime time) => new()
         {
-            return new DataPoint()
-            {
-                Time = Time.Add(timeShift),
-                Value = Value
-            };
-        }
+            Time = time,
+            Value = Value
+        };
 
-        public DataPoint Negate()
+        public DataPoint NewValue(double value) => new()
         {
-            return new DataPoint()
-            {
-                Time = Time,
-                Value = -Value
-            };
-        }
+            Time = Time,
+            Value = value
+        };
+
+        public DataPoint Shift(TimeSpan timeShift) =>
+            NewTime(Time + timeShift);
+
+        public DataPoint Negate() =>
+            NewValue(-Value);
 
         public DataPoint Add(DataPoint point)
         {
             if (Time != point.Time)
                 throw new InvalidOperationException("Cannot add datapoints with mismatched times");
 
-            return new DataPoint()
-            {
-                Time = Time,
-                Value = Value + point.Value
-            };
+            return NewValue(Value + point.Value);
         }
 
-        public DataPoint Subtract(DataPoint point)
-        {
-            return Add(point.Negate());
-        }
+        public DataPoint Subtract(DataPoint point) =>
+            Add(point.Negate());
 
-        public DataPoint Add(double value)
-        {
-            return new DataPoint()
-            {
-                Time = Time,
-                Value = Value + value
-            };
-        }
+        public DataPoint Add(double value) =>
+            NewValue(Value + value);
 
-        public DataPoint Subtract(double value)
-        {
-            return Add(-value);
-        }
+        public DataPoint Subtract(double value) =>
+            Add(-value);
 
-        public DataPoint Multiply(double value)
-        {
-            return new DataPoint()
-            {
-                Time = Time,
-                Value = Value * value
-            };
-        }
+        public DataPoint Multiply(double value) =>
+            NewValue(Value * value);
 
-        public bool LargerThan(double comparison)
-        {
-            return Value > comparison;
-        }
+        public bool IsLargerThan(double comparison) =>
+            Value > comparison;
 
-        public bool LargerThan(DataPoint point)
-        {
-            return LargerThan(point.Value);
-        }
+        public bool IsLargerThan(DataPoint point) =>
+            IsLargerThan(point.Value);
+
+        [Obsolete("Use IsLargerThan() instead")]
+        public bool LargerThan(double comparison) =>
+            IsLargerThan(comparison);
+
+        [Obsolete("Use IsLargerThan() instead")]
+        public bool LargerThan(DataPoint point) =>
+            IsLargerThan(point);
 
         #endregion
     }

--- a/Source/Libraries/openXDA.Model/IsExternalInit.cs
+++ b/Source/Libraries/openXDA.Model/IsExternalInit.cs
@@ -1,0 +1,6 @@
+﻿// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices;
+
+// Class defined in .NET 5.0 and later, but not in .NET Framework or Standard 2.x.
+// Declared manually here to allow 'init' property operations.
+internal static class IsExternalInit { }

--- a/Source/Libraries/openXDA.Model/openXDA.Model.csproj
+++ b/Source/Libraries/openXDA.Model/openXDA.Model.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -146,6 +147,7 @@
     <Compile Include="Files\AnalysisTask.cs" />
     <Compile Include="Files\FileGroupField.cs" />
     <Compile Include="Files\FileGroupFieldValue.cs" />
+    <Compile Include="IsExternalInit.cs" Visible="false" />
     <Compile Include="LazyContext.cs" />
     <Compile Include="Links\UserAccountScheduledEmailType.cs" />
     <Compile Include="Links\LineSegmentConnections.cs" />

--- a/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisNode.cs
@@ -408,16 +408,24 @@ namespace openXDA.Nodes.Types.Analysis
 
         private void ShiftTime(MeterDataSet meterDataSet, Func<DateTime, DateTime> toXDATime)
         {
+            DataPoint ToXDATime(DataPoint point)
+            {
+                DateTime xdaTime = toXDATime(point.Time);
+                return point.NewTime(xdaTime);
+            }
+
             foreach (DataSeries dataSeries in meterDataSet.DataSeries)
             {
-                foreach (DataPoint dataPoint in dataSeries.DataPoints)
-                    dataPoint.Time = toXDATime(dataPoint.Time);
+                dataSeries.DataPoints = dataSeries.DataPoints
+                    .Select(ToXDATime)
+                    .ToList();
             }
 
             foreach (DataSeries dataSeries in meterDataSet.Digitals)
             {
-                foreach (DataPoint dataPoint in dataSeries.DataPoints)
-                    dataPoint.Time = toXDATime(dataPoint.Time);
+                dataSeries.DataPoints = dataSeries.DataPoints
+                    .Select(ToXDATime)
+                    .ToList();
             }
 
             for (int i = 0; i < meterDataSet.ReportedDisturbances.Count; i++)
@@ -604,8 +612,8 @@ namespace openXDA.Nodes.Types.Analysis
 
             foreach (DataSeries analogSeries in meterDataSet.DataSeries)
             {
-                foreach (DataPoint point in analogSeries.DataPoints)
-                    point.Value *= adjustment;
+                DataSeries adjusted = analogSeries.Multiply(adjustment);
+                analogSeries.DataPoints = adjusted.DataPoints;
             }
         }
 


### PR DESCRIPTION
Visual Studio profiler suggests that this uses half as much RAM for the `MeterDataSet` as the `DataPoint` class does, however it's not clear to me what effect this will have on process memory or CPU usage. I would like to run a test at TVA to see if this reduces RAM usage and/or CPU usage there. If not, it's probably not worth the effort to merge this and roll down into the web apps.