### PR TITLE
Move wixproj project reference to the end of the solution file

### DIFF
--- a/Source/openXDA.sln
+++ b/Source/openXDA.sln
@@ -88,11 +88,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "openXDA", "Applications\ope
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "openXDAConsole", "Applications\openXDA\openXDAConsole\openXDAConsole.csproj", "{72F417E9-F592-4417-B87C-B681AE707294}"
 EndProject
-Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "openXDASetup", "Applications\openXDA\openXDASetup\openXDASetup.wixproj", "{36380070-81B6-4D71-A80A-C5AE76B0E357}"
-	ProjectSection(ProjectDependencies) = postProject
-		{CE674B18-F140-47E4-A22C-8E7C37FAA974} = {CE674B18-F140-47E4-A22C-8E7C37FAA974}
-	EndProjectSection
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "openHistorian.XDALink.SqlClr", "Libraries\openHistorian.XDALink.SqlClr\openHistorian.XDALink.SqlClr.csproj", "{C6C6E49B-4E72-4C3D-90AB-66152E7FEFBF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "openHistorian.XDALink", "Libraries\openHistorian.XDALink\openHistorian.XDALink.csproj", "{7F731255-FA83-4DBF-9E0F-C22AE4845E76}"
@@ -161,6 +156,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FLEE", "FLEE", "{C7A4CCDE-4
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "openXDA.APIMiddleware", "Libraries\openXDA.APIMiddleware\openXDA.APIMiddleware.csproj", "{AB824302-D4F1-4173-A46E-5328C31F4D65}"
+EndProject
+Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "openXDASetup", "Applications\openXDA\openXDASetup\openXDASetup.wixproj", "{36380070-81B6-4D71-A80A-C5AE76B0E357}"
+	ProjectSection(ProjectDependencies) = postProject
+		{CE674B18-F140-47E4-A22C-8E7C37FAA974} = {CE674B18-F140-47E4-A22C-8E7C37FAA974}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
As suggested by https://stackoverflow.com/a/2738267

> Its a bug, a bug, a bug. I don't know, who is responsible, but here's a working dirty filthy hack:
> 
> 1. Open your .sln file in notepad.
> 2. Find your wix projects in the list of projects.
> 3. Cut them out, and paste them back after all other projects are listed.