### PR TITLE
Rabbit mq XDA-68

### DIFF
--- a/Source/Data/01 - openXDA.sql
+++ b/Source/Data/01 - openXDA.sql
@@ -325,6 +325,9 @@ GO
 INSERT INTO NodeType VALUES('Grafana', 'openXDA.Nodes.dll', 'openXDA.Nodes.Types.Grafana.GrafanaHostingNode')
 GO
 
+INSERT INTO NodeType VALUES('RabbitMQ', 'openXDA.Nodes.dll', 'openXDA.Nodes.Types.RabbitMQ.RabbitMQNode')
+GO
+
 CREATE TABLE Node
 (
     ID INT IDENTITY(1, 1) NOT NULL PRIMARY KEY,
@@ -361,6 +364,9 @@ INSERT INTO Node VALUES((SELECT ID FROM NodeType WHERE TypeName = 'openXDA.Nodes
 GO
 
 INSERT INTO Node VALUES((SELECT ID FROM NodeType WHERE TypeName = 'openXDA.Nodes.Types.DataPusher.DataPusherNode'), NULL, NULL, 'Data Pusher', 1)
+GO
+
+INSERT INTO Node VALUES((SELECT ID FROM NodeType WHERE TypeName = 'openXDA.Nodes.Types.RabbitMQ.RabbitMQNode'), NULL, NULL, 'RabbitMQ Listener', 1)
 GO
 
 CREATE TABLE NodeSetting

--- a/Source/Data/05 - DefaultSettings.sql
+++ b/Source/Data/05 - DefaultSettings.sql
@@ -449,6 +449,21 @@ GO
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('LSCVS.TypeThreshold', '0.95', '0.95')
 GO
 
+INSERT INTO Setting(Name, Value, DefaultValue) VALUES('RabbitMQ.Enabled', 'false', 'false')
+GO
+
+INSERT INTO Setting(Name, Value, DefaultValue) VALUES('RabbitMQ.ExchangeName', 'openxda', 'openxda')
+GO
+
+INSERT INTO Setting(Name, Value, DefaultValue) VALUES('RabbitMQ.RoutingKey', 'openxda', 'openxda')
+GO
+
+INSERT INTO Setting(Name, Value, DefaultValue) VALUES('RabbitMQ.Hostname', 'localhost', 'localhost')
+GO
+
+INSERT INTO Setting(Name, Value, DefaultValue) VALUES('RabbitMQ.Port', '5672', '5672')
+GO
+
 INSERT INTO DashSettings(Name, Value, Enabled) VALUES('DashTab', '#tabsEvents', 1)
 GO
 

--- a/Source/Data/05 - DefaultSettings.sql
+++ b/Source/Data/05 - DefaultSettings.sql
@@ -464,6 +464,9 @@ GO
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('RabbitMQ.Port', '5672', '5672')
 GO
 
+INSERT INTO Setting(Name, Value, DefaultValue) VALUES('RabbitMQ.OutboundRoutingKey', 'analytic', 'analytic')
+GO
+
 INSERT INTO DashSettings(Name, Value, Enabled) VALUES('DashTab', '#tabsEvents', 1)
 GO
 

--- a/Source/Libraries/openXDA.Configuration/RabbitMQSection.cs
+++ b/Source/Libraries/openXDA.Configuration/RabbitMQSection.cs
@@ -21,17 +21,14 @@
 //
 //******************************************************************************************************
 
-using System;
 using System.ComponentModel;
 using System.Configuration;
-using GSF.Configuration;
 
 namespace openXDA.Configuration
 {
     public class RabbitMQSection
     {
         public const string CategoryName = "RabbitMQ";
-
 
         /// <summary>
         /// The RabbbitMQ Server Hostname or IP Address.

--- a/Source/Libraries/openXDA.Configuration/RabbitMQSection.cs
+++ b/Source/Libraries/openXDA.Configuration/RabbitMQSection.cs
@@ -67,5 +67,13 @@ namespace openXDA.Configuration
         [Setting]
         [DefaultValue(false)]
         public bool Enabled { get; set; } = false;
+
+
+        /// <summary>
+        /// Defines the routing key used for outbound messages.
+        /// </summary>
+        [Setting]
+        [DefaultValue("analytic")]
+        public string OutboundRoutingKey { get; set; } = "analytic";
     }
 }

--- a/Source/Libraries/openXDA.Configuration/RabbitMQSection.cs
+++ b/Source/Libraries/openXDA.Configuration/RabbitMQSection.cs
@@ -1,0 +1,71 @@
+﻿//******************************************************************************************************
+//  RabbitMQSection.cs - Gbtc
+//
+//  Copyright © 2025, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  11/01/2025 - C. Lackner
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.ComponentModel;
+using System.Configuration;
+using GSF.Configuration;
+
+namespace openXDA.Configuration
+{
+    public class RabbitMQSection
+    {
+        public const string CategoryName = "RabbitMQ";
+
+
+        /// <summary>
+        /// The RabbbitMQ Server Hostname or IP Address.
+        /// </summary>
+        [Setting]
+        [DefaultValue("localhost")]
+        public string Hostname { get; set; } = "localhost";
+
+        /// <summary>
+        /// Defines the port RabbitMQ is listening on.
+        /// </summary>
+        [Setting]
+        [DefaultValue(5672)]
+        public int Port { get; set; } = 5672;
+
+        /// <summary>
+        /// Defines the name of the exchange to listen to.
+        /// </summary>
+        [Setting]
+        [DefaultValue("openxda")]
+        public string ExchangeName { get; set; } = "openxda";
+
+        /// <summary>
+        /// Defines the routing key used to listen for messages.
+        /// </summary>
+        [Setting]
+        [DefaultValue("openxda")]
+        public string RoutingKey { get; set; } = "openxda";
+
+        /// <summary>
+        /// Defines a flag that determines if RabbitMQ integration is enabled.
+        /// </summary>
+        [Setting]
+        [DefaultValue(false)]
+        public bool Enabled { get; set; } = false;
+    }
+}

--- a/Source/Libraries/openXDA.Configuration/openXDA.Configuration.csproj
+++ b/Source/Libraries/openXDA.Configuration/openXDA.Configuration.csproj
@@ -116,7 +116,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Source/Libraries/openXDA.Configuration/openXDA.Configuration.csproj
+++ b/Source/Libraries/openXDA.Configuration/openXDA.Configuration.csproj
@@ -35,8 +35,42 @@
     <Reference Include="GSF.Core">
       <HintPath>..\..\Dependencies\GSF\GSF.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="RabbitMQ.Client, Version=7.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\RabbitMQ.Client.7.2.0\lib\netstandard2.0\RabbitMQ.Client.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Diagnostics.DiagnosticSource.8.0.1\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Pipelines, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.IO.Pipelines.8.0.0\lib\net462\System.IO.Pipelines.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Channels, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Threading.Channels.8.0.0\lib\net462\System.Threading.Channels.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.RateLimiting, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Threading.RateLimiting.8.0.0\lib\net462\System.Threading.RateLimiting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Http, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -52,6 +86,7 @@
     <Compile Include="GrafanaSection.cs" />
     <Compile Include="OSIPISection.cs" />
     <Compile Include="SCADASection.cs" />
+    <Compile Include="RabbitMQSection.cs" />
     <Compile Include="SSAMSSection.cs" />
     <Compile Include="Subscription.cs" />
     <Compile Include="LSCVSSection.cs" />
@@ -79,6 +114,10 @@
       <Project>{A1A0BC13-50ED-4DC9-8C1E-3293B0B69281}</Project>
       <Name>openXDA.Model</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/Libraries/openXDA.Configuration/openXDA.Configuration.csproj
+++ b/Source/Libraries/openXDA.Configuration/openXDA.Configuration.csproj
@@ -35,42 +35,8 @@
     <Reference Include="GSF.Core">
       <HintPath>..\..\Dependencies\GSF\GSF.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-    </Reference>
-    <Reference Include="RabbitMQ.Client, Version=7.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\RabbitMQ.Client.7.2.0\lib\netstandard2.0\RabbitMQ.Client.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
-    </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Diagnostics.DiagnosticSource.8.0.1\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
-    </Reference>
-    <Reference Include="System.IO.Pipelines, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.IO.Pipelines.8.0.0\lib\net462\System.IO.Pipelines.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Channels, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Threading.Channels.8.0.0\lib\net462\System.Threading.Channels.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.RateLimiting, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Threading.RateLimiting.8.0.0\lib\net462\System.Threading.RateLimiting.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
     <Reference Include="System.Web.Http, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -114,9 +80,6 @@
       <Project>{A1A0BC13-50ED-4DC9-8C1E-3293B0B69281}</Project>
       <Name>openXDA.Model</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/EventDataMessage.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/EventDataMessage.cs
@@ -1,0 +1,67 @@
+﻿//******************************************************************************************************
+//  EventDataMessage.cs - Gbtc
+//
+//  Copyright © 2021, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  11/20/2025 - C. Lackner
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using GSF;
+using GSF.Configuration;
+using GSF.Data;
+using GSF.IO;
+using GSF.Parsing;
+using log4net;
+using Newtonsoft.Json.Linq;
+using openXDA.Configuration;
+using openXDA.Model;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+
+namespace openXDA.Nodes.Types.RabbitMQ
+{
+    public class EventDataMessage 
+    {
+        /// <summary>
+        /// Unique ebvent identifier used in response
+        /// </summary>
+        public int event_id { get; set; }
+        public double[] Va { get; set; } 
+        public double[] Vb { get; set; }
+        public double[] Vc { get; set; }
+        /// <summary>
+        /// Samples Per Cycle
+        /// </summary>
+        public int sample_rate { get; set; } 
+        /// <summary>
+        /// Samples per second
+        /// </summary>
+        public double sample_frequency { get; set; }
+        public int event_start_idx { get; set; }
+        public string event_type { get; set; }
+    }
+}

--- a/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/EventDataMessage.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/EventDataMessage.cs
@@ -21,42 +21,21 @@
 //
 //******************************************************************************************************
 
-using GSF;
-using GSF.Configuration;
-using GSF.Data;
-using GSF.IO;
-using GSF.Parsing;
-using log4net;
-using Newtonsoft.Json.Linq;
-using openXDA.Configuration;
-using openXDA.Model;
-using RabbitMQ.Client;
-using RabbitMQ.Client.Events;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
-using System.Threading.Channels;
-using System.Threading.Tasks;
-using System.Web.Http;
-using System.Web.Http.Controllers;
-
 namespace openXDA.Nodes.Types.RabbitMQ
 {
-    public class EventDataMessage 
+    public class EventDataMessage
     {
         /// <summary>
-        /// Unique ebvent identifier used in response
+        /// Unique event identifier used in response
         /// </summary>
         public int event_id { get; set; }
-        public double[] Va { get; set; } 
+        public double[] Va { get; set; }
         public double[] Vb { get; set; }
         public double[] Vc { get; set; }
         /// <summary>
         /// Samples Per Cycle
         /// </summary>
-        public int sample_rate { get; set; } 
+        public int sample_rate { get; set; }
         /// <summary>
         /// Samples per second
         /// </summary>

--- a/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/EventTagMessage.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/EventTagMessage.cs
@@ -21,30 +21,11 @@
 //
 //******************************************************************************************************
 
-using GSF;
-using GSF.Configuration;
-using GSF.Data;
-using GSF.IO;
-using GSF.Parsing;
-using log4net;
 using Newtonsoft.Json.Linq;
-using openXDA.Configuration;
-using openXDA.Model;
-using RabbitMQ.Client;
-using RabbitMQ.Client.Events;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.Text;
-using System.Threading.Channels;
-using System.Threading.Tasks;
-using System.Web.Http;
-using System.Web.Http.Controllers;
 
 namespace openXDA.Nodes.Types.RabbitMQ
 {
-    public class EventTagMessage 
+    public class EventTagMessage
     {
         public int event_id { get; set; }
         public string event_type { get; set; }

--- a/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/EventTagMessage.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/EventTagMessage.cs
@@ -1,0 +1,53 @@
+﻿//******************************************************************************************************
+//  EventTagMessage.cs - Gbtc
+//
+//  Copyright © 2021, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  11/20/2025 - C. Lackner
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using GSF;
+using GSF.Configuration;
+using GSF.Data;
+using GSF.IO;
+using GSF.Parsing;
+using log4net;
+using Newtonsoft.Json.Linq;
+using openXDA.Configuration;
+using openXDA.Model;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+
+namespace openXDA.Nodes.Types.RabbitMQ
+{
+    public class EventTagMessage 
+    {
+        public int event_id { get; set; }
+        public string event_type { get; set; }
+        public JObject details { get; set; }
+    }
+}

--- a/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/RabbitMQNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/RabbitMQNode.cs
@@ -1,0 +1,219 @@
+﻿//******************************************************************************************************
+//  RabbitMQNode.cs - Gbtc
+//
+//  Copyright © 2021, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  02/08/2021 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using GSF;
+using GSF.Configuration;
+using GSF.Data;
+using GSF.Data.Model;
+using GSF.IO;
+using GSF.Parsing;
+using log4net;
+using Newtonsoft.Json;
+using openXDA.Configuration;
+using openXDA.Model;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+
+namespace openXDA.Nodes.Types.RabbitMQ
+{
+    public class RabbitMQNode : NodeBase, IDisposable
+    {
+        #region [ Members ]
+
+
+        // Nested Types
+        private class Settings
+        {
+            public Settings(Action<object> configure) =>
+                configure(this);
+
+            [Category]
+            [SettingName(RabbitMQSection.CategoryName)]
+            public RabbitMQSection RabbitMQSettings { get; } = new RabbitMQSection();
+        }
+
+        private Action<object> Configurator { get; set; }
+
+        private class RabbitMQWebController : ApiController
+        {
+            private RabbitMQNode Node { get; }
+
+            public RabbitMQWebController(RabbitMQNode node) =>
+                Node = node;
+
+            [HttpGet]
+            public void Reconfigure() =>
+                Node.Reconfigure();
+        }
+
+        private bool m_disposed { get; set; }
+
+        private IConnection m_connection { get; set; }
+        private IChannel m_channel { get; set; }
+        #endregion
+
+        public RabbitMQNode(Host host, Node definition, NodeType type)
+            : base(host, definition, type)
+        {
+            Configurator = GetConfigurator();
+            Connect();
+        }
+
+        #region [ Methods ]
+
+        public override IHttpController CreateWebController() =>
+            new RabbitMQWebController(this);
+
+        private void Configure(object obj) => Configurator(obj);
+
+        protected override void OnReconfigure(Action<object> configurator)
+        {
+            Configure(configurator);
+            Connect();
+        }
+
+        /// <summary>
+        /// Create a Connection to the RabbitMQServer
+        /// </summary>
+        private async Task Connect()
+        {
+            Settings settings = new Settings(Configure);
+
+            if (!(m_channel is null))
+            {
+                m_channel.Dispose();
+
+            }
+
+            if (!(m_connection is null))
+            {
+                m_connection.Dispose();
+            }
+
+            if (!settings.RabbitMQSettings.Enabled)
+                return;
+
+
+            Log.Debug("Creating Connection to RabbitMQ Server.");
+            try 
+            { 
+                var factory = new ConnectionFactory { HostName = settings.RabbitMQSettings.Hostname, Port = settings.RabbitMQSettings.Port, VirtualHost = "/", UserName = "guest" };
+
+                m_connection = await factory.CreateConnectionAsync().ConfigureAwait(false);
+                m_channel = await m_connection.CreateChannelAsync().ConfigureAwait(false);
+                await m_channel.ExchangeDeclareAsync(exchange: settings.RabbitMQSettings.ExchangeName, type: ExchangeType.Direct, durable: true).ConfigureAwait(false);
+
+                await m_channel.QueueDeclareAsync(queue: "hello", durable: true, exclusive: true, autoDelete: false, arguments: null);
+
+
+                QueueDeclareOk queueDeclareResult = await m_channel.QueueDeclareAsync();
+                await m_channel.QueueBindAsync(queue: queueDeclareResult.QueueName, exchange: settings.RabbitMQSettings.ExchangeName, routingKey: settings.RabbitMQSettings.RoutingKey).ConfigureAwait(false);
+
+                var consumer = new AsyncEventingBasicConsumer(m_channel);
+                consumer.ReceivedAsync += (model, ea) =>
+                {
+                    var body = ea.Body.ToArray();
+                    string message = Encoding.UTF8.GetString(body);
+                    MessageCallback(message);
+                    return Task.CompletedTask;
+                };
+
+                Task.Run(() => m_channel.BasicConsumeAsync(queueDeclareResult.QueueName, autoAck: true, consumer: consumer));
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Unable to Connect to RabbitMQ Server", ex);
+            }
+
+        }
+
+        private void MessageCallback(string message)
+        {
+            Log.Info("RabbitMQ Message recieved");
+            EventTagMessage eventTagMessage = JsonConvert.DeserializeObject<EventTagMessage>(message);
+
+            if (eventTagMessage is null || string.IsNullOrEmpty(eventTagMessage.event_type))
+            {
+                Log.Warn("Unable to deserialize RabbitMQ message to proper format");
+                return;
+            }
+
+            using (AdoDataConnection connection = CreateDbConnection())
+            {
+                EventTag tag = new TableOperations<EventTag>(connection).GetOrAdd(eventTagMessage.event_type);
+
+                // Ensure Event exists
+                Event evt = new TableOperations<Event>(connection).QueryRecordWhere("ID = {0}", eventTagMessage.event_id);
+                if ( evt is null)
+                {
+                    Log.Warn($"No event found for event_id {eventTagMessage.event_id}");
+                    return;
+                }
+
+                EventEventTag entry = new EventEventTag()
+                {
+                    EventID = eventTagMessage.event_id,
+                    EventTagID = tag.ID,
+                    TagData = JsonConvert.SerializeObject(eventTagMessage.details)
+                };
+
+                new TableOperations<EventEventTag>(connection).AddNewRecord(entry);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (m_disposed)
+                return;
+
+            try
+            {
+                m_channel.Dispose();
+                m_connection.Dispose();
+
+            }
+            finally
+            {
+                m_disposed = true;
+            }
+        }
+
+        #endregion
+
+        #region [ Static ]
+
+        // Static Fields
+        private static readonly ILog Log = LogManager.GetLogger(typeof(RabbitMQNode));
+
+        #endregion
+    }
+}

--- a/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/RabbitMQNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/RabbitMQNode.cs
@@ -110,7 +110,7 @@ namespace openXDA.Nodes.Types.RabbitMQ
         protected override void OnReconfigure(Action<object> configurator)
         {
             Configure(configurator);
-            ConnectAsync();
+            ConnectAsync().GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/RabbitMQNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/RabbitMQ/RabbitMQNode.cs
@@ -82,7 +82,7 @@ namespace openXDA.Nodes.Types.RabbitMQ
             : base(host, definition, type)
         {
             Configurator = GetConfigurator();
-            ConnectAsync();
+            ConnectAsync().GetAwaiter().GetResult();
         }
 
         #endregion

--- a/Source/Libraries/openXDA.Nodes/openXDA.Nodes.csproj
+++ b/Source/Libraries/openXDA.Nodes/openXDA.Nodes.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Types\Grafana\GrafanaAuthProxyController.cs" />
     <Compile Include="Types\Grafana\GrafanaHostingNode.cs" />
     <Compile Include="Types\Grafana\GrafanaQueryHelper.cs" />
+    <Compile Include="Types\RabbitMQ\EventDataMessage.cs" />
     <Compile Include="Types\RabbitMQ\EventTagMessage.cs" />
     <Compile Include="Types\RabbitMQ\RabbitMQNode.cs" />
     <Compile Include="Types\SSAMS\SSAMSNode.cs" />
@@ -155,7 +156,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Types\Grafana\custom.ini" />
   </ItemGroup>

--- a/Source/Libraries/openXDA.Nodes/openXDA.Nodes.csproj
+++ b/Source/Libraries/openXDA.Nodes/openXDA.Nodes.csproj
@@ -44,18 +44,52 @@
     <Reference Include="log4net, Version=3.1.0.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\log4net.3.1.0\lib\net462\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Dependencies\GSF\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="RabbitMQ.Client, Version=7.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\RabbitMQ.Client.7.2.0\lib\netstandard2.0\RabbitMQ.Client.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Diagnostics.DiagnosticSource.8.0.1\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Pipelines, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.IO.Pipelines.8.0.0\lib\net462\System.IO.Pipelines.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http.Formatting, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Dependencies\GSF\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Channels, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Threading.Channels.8.0.0\lib\net462\System.Threading.Channels.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.RateLimiting, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Threading.RateLimiting.8.0.0\lib\net462\System.Threading.RateLimiting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Http">
       <HintPath>..\..\Dependencies\GSF\System.Web.Http.dll</HintPath>
@@ -98,6 +132,8 @@
     <Compile Include="Types\Grafana\GrafanaAuthProxyController.cs" />
     <Compile Include="Types\Grafana\GrafanaHostingNode.cs" />
     <Compile Include="Types\Grafana\GrafanaQueryHelper.cs" />
+    <Compile Include="Types\RabbitMQ\EventTagMessage.cs" />
+    <Compile Include="Types\RabbitMQ\RabbitMQNode.cs" />
     <Compile Include="Types\SSAMS\SSAMSNode.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -119,6 +155,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Types\Grafana\custom.ini" />
   </ItemGroup>

--- a/Source/Libraries/openXDA.Nodes/packages.config
+++ b/Source/Libraries/openXDA.Nodes/packages.config
@@ -1,4 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="3.1.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
+  <package id="RabbitMQ.Client" version="7.2.0" targetFramework="net48" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Diagnostics.DiagnosticSource" version="8.0.1" targetFramework="net48" />
+  <package id="System.IO.Pipelines" version="8.0.0" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
+  <package id="System.Threading.Channels" version="8.0.0" targetFramework="net48" />
+  <package id="System.Threading.RateLimiting" version="8.0.0" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
This adds integration with Rabbit MQ.
(1) The system will send a message to the Broker when an event is processed.
(2) The system will receive messages and attach them to events via `EventTag`s

Inbound messages look like:
```
 event_id: int
 event_type: str
 details: dict[str, Any]
```
    
Outbound messages look like:
```
  event_id: int
  Va: list[float | None] 
  Vb: list[float | None] 
  Vc: list[float | None] 
  sample_rate: int  # Samples per cycle
  sample_frequency: float  # Hz (samples per second)
  event_start_idx: int
  event_type: str | None
```
    
The following Settings are used to establish connection to RabbitMQ:
`RabbitMQ.Port`
`RabbitMQ.Enabled`
`RabbitMQ.RoutingKey`
`RabbitMQ.OutboundRoutingKey`

It also adds the `Node` and `NodeType` entry in the SQL Files.

Testing was done using the RabbitMQ Docker image and the attached Python files:

[event_model.py](https://github.com/user-attachments/files/23796009/event_model.py)
[exchanges.py](https://github.com/user-attachments/files/23796010/exchanges.py)
[queues.py](https://github.com/user-attachments/files/23796011/queues.py)
[ReadFromBus.py](https://github.com/user-attachments/files/23796012/ReadFromBus.py)
[WriteToBus.py](https://github.com/user-attachments/files/23796013/WriteToBus.py)

Run `WriteToBus` to write messages to XDA and `ReadToBus` to read them comming from XDA

This requires: https://github.com/GridProtectionAlliance/gsf/pull/453
