### PR TITLE
include N/A status if no ScadaHistorianResource configured

### DIFF
--- a/Source/Libraries/FaultData/DataResources/SCADADataResource.cs
+++ b/Source/Libraries/FaultData/DataResources/SCADADataResource.cs
@@ -121,6 +121,14 @@ namespace FaultData.DataResources
 
         public AppStatus GetHistorianHealth()
         {
+            if (SCADAHistorianResource == null)
+            {
+                return new AppStatus()
+                {
+                    Status = "N/A",
+                    Details = []
+                };
+            }
             return SCADAHistorianResource.GetHealth();
         }
 


### PR DESCRIPTION
Add a null check to return an N/A App Status, preventing 'null' responses.