### PR TITLE
XDA-77 Make log file locations configurable

### DIFF
--- a/Source/Applications/openXDA/openXDA/App.config
+++ b/Source/Applications/openXDA/openXDA/App.config
@@ -83,6 +83,21 @@
       <add name="AzureADConfigSource" value="appsettings.json" description="Azure AD configuration source. Either 'appsettings.json' file path or settings category to use." encrypted="false" />
       <add name="AzureADSecret" value="env(User:openXDASecretKey)" description="Defines the Azure AD secret value to be used for user info and group lookups, post authentication." encrypted="false" />
     </securityProvider>
+    <xdaDebugLog>
+      <add name="LogPath" value="Debug\openXDA\openXDA.log" description="Path to the log files produced by this log category." encrypted="false" />
+      <add name="MaxSizeRollBackups" value="10" description="The maximum number of log files produced per day." encrypted="false" />
+      <add name="MaximumFileSize" value="1MB" description="The maximum size of each log file produced. (Allowed suffixes: KB, MB, GB)" encrypted="false" />
+    </xdaDebugLog>
+    <skippedFilesLog>
+      <add name="LogPath" value="Debug\SkippedFiles\SkippedFiles.log" description="Path to the log files produced by this log category." encrypted="false" />
+      <add name="MaxSizeRollBackups" value="10" description="The maximum number of log files produced per day." encrypted="false" />
+      <add name="MaximumFileSize" value="1MB" description="The maximum size of each log file produced. (Allowed suffixes: KB, MB, GB)" encrypted="false" />
+    </skippedFilesLog>
+    <gsfDebugLog>
+      <add name="LogPath" value="Debug\gsf\gsf.log" description="Path to the log files produced by this log category." encrypted="false" />
+      <add name="MaxSizeRollBackups" value="10" description="The maximum number of log files produced per day." encrypted="false" />
+      <add name="MaximumFileSize" value="1MB" description="The maximum size of each log file produced. (Allowed suffixes: KB, MB, GB)" encrypted="false" />
+    </gsfDebugLog>
 	<dbLightning>
 		<add name="ConnectionString" value="Data Source=localhost; Initial Catalog=Lightning; Integrated Security=SSPI" description="Defines the connection to the Lightning Data database." encrypted="false" />
 		<add name="DataProviderString" value="AssemblyName={System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089}; ConnectionType=System.Data.SqlClient.SqlConnection; AdapterType=System.Data.SqlClient.SqlDataAdapter" description="Configuration database ADO.NET data provider assembly type creation string used when ConfigurationType=Database" encrypted="false" />

--- a/Source/Applications/openXDA/openXDA/AppDebug.config
+++ b/Source/Applications/openXDA/openXDA/AppDebug.config
@@ -102,6 +102,21 @@
       <add name="PasswordRequirementsRegex" value="^.*(?=.{8,})(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).*$" description="Regular expression used to validate new passwords for database users." encrypted="false" />
       <add name="PasswordRequirementsError" value="Invalid Password: Password must be at least 8 characters; must contain at least 1 number, 1 upper case letter, and 1 lower case letter" description="Error message to be displayed when new database user password fails regular expression test." encrypted="false" />
     </alternateSecurityProvider>
+    <xdaDebugLog>
+      <add name="LogPath" value="Debug\openXDA\openXDA.log" description="Path to the log files produced by this log category." encrypted="false" />
+      <add name="MaxSizeRollBackups" value="10" description="The maximum number of log files produced per day." encrypted="false" />
+      <add name="MaximumFileSize" value="1MB" description="The maximum size of each log file produced. (Allowed suffixes: KB, MB, GB)" encrypted="false" />
+    </xdaDebugLog>
+    <skippedFilesLog>
+      <add name="LogPath" value="Debug\SkippedFiles\SkippedFiles.log" description="Path to the log files produced by this log category." encrypted="false" />
+      <add name="MaxSizeRollBackups" value="10" description="The maximum number of log files produced per day." encrypted="false" />
+      <add name="MaximumFileSize" value="1MB" description="The maximum size of each log file produced. (Allowed suffixes: KB, MB, GB)" encrypted="false" />
+    </skippedFilesLog>
+    <gsfDebugLog>
+      <add name="LogPath" value="Debug\gsf\gsf.log" description="Path to the log files produced by this log category." encrypted="false" />
+      <add name="MaxSizeRollBackups" value="10" description="The maximum number of log files produced per day." encrypted="false" />
+      <add name="MaximumFileSize" value="1MB" description="The maximum size of each log file produced. (Allowed suffixes: KB, MB, GB)" encrypted="false" />
+    </gsfDebugLog>
 	<dbLightning>
 		<add name="ConnectionString" value="Data Source=localhost; Initial Catalog=Lightning; Integrated Security=SSPI" description="Defines the connection to the Lightning Data database." encrypted="false" />
 		<add name="DataProviderString" value="AssemblyName={System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089}; ConnectionType=System.Data.SqlClient.SqlConnection; AdapterType=System.Data.SqlClient.SqlDataAdapter" description="Configuration database ADO.NET data provider assembly type creation string used when ConfigurationType=Database" encrypted="false" />

--- a/Source/Applications/openXDA/openXDA/ServiceHost.cs
+++ b/Source/Applications/openXDA/openXDA/ServiceHost.cs
@@ -265,82 +265,79 @@ namespace openXDA
             securityProvider.Add("DataProviderString", "Eval(systemSettings.DataProviderString)", "Configuration database ADO.NET data provider assembly type creation string to be used for connection to the backend security datastore.");
         }
 
-        private void InitializeLogging()
+        private RollingFileAppender InitializeRollingFileAppender(string settingsCategory, string defaultPath)
         {
-            ServiceHelperAppender serviceHelperAppender = new ServiceHelperAppender(m_serviceHelper);
-
-            RollingFileAppender debugLogAppender = new RollingFileAppender();
-            debugLogAppender.File = "openXDA.log";
-            debugLogAppender.StaticLogFileName = false;
-            debugLogAppender.AppendToFile = true;
-            debugLogAppender.RollingStyle = RollingFileAppender.RollingMode.Composite;
-            debugLogAppender.MaxSizeRollBackups = 10;
-            debugLogAppender.PreserveLogFileNameExtension = true;
-            debugLogAppender.MaximumFileSize = "1MB";
-            debugLogAppender.Layout = new PatternLayout("%date [%thread] %-5level %logger - %message%newline");
-            debugLogAppender.AddFilter(new FileSkippedExceptionFilter());
-
-            RollingFileAppender skippedFilesAppender = new RollingFileAppender();
-            skippedFilesAppender.File = "SkippedFiles.log";
-            skippedFilesAppender.StaticLogFileName = false;
-            skippedFilesAppender.AppendToFile = true;
-            skippedFilesAppender.RollingStyle = RollingFileAppender.RollingMode.Composite;
-            skippedFilesAppender.MaxSizeRollBackups = 10;
-            skippedFilesAppender.PreserveLogFileNameExtension = true;
-            skippedFilesAppender.MaximumFileSize = "1MB";
-            skippedFilesAppender.Layout = new PatternLayout("%date [%thread] %-5level %logger - %message%newline");
-            skippedFilesAppender.AddFilter(new FileSkippedExceptionFilter(false));
-
-            RollingFileAppender gsfLogAppender = new RollingFileAppender();
-            gsfLogAppender.File = "gsf.log";
-            gsfLogAppender.StaticLogFileName = false;
-            gsfLogAppender.AppendToFile = true;
-            gsfLogAppender.RollingStyle = RollingFileAppender.RollingMode.Composite;
-            gsfLogAppender.MaxSizeRollBackups = 10;
-            gsfLogAppender.PreserveLogFileNameExtension = true;
-            gsfLogAppender.MaximumFileSize = "1MB";
-            gsfLogAppender.Layout = new PatternLayout("%date [%thread] %-5level %logger - %message%newline");
-
-            string logFileSize = Environment.GetEnvironmentVariable("openXDA_DebugLogFileSize");
-            string logFileBackups = Environment.GetEnvironmentVariable("openXDA_DebugLogFileBackups");
-
-            if (!string.IsNullOrEmpty(logFileSize))
-            {
-                debugLogAppender.MaximumFileSize = logFileSize;
-                skippedFilesAppender.MaximumFileSize = logFileSize;
-                gsfLogAppender.MaximumFileSize = logFileSize;
-            }
-
-            if (int.TryParse(logFileBackups, out int backups))
-            {
-                debugLogAppender.MaxSizeRollBackups = backups;
-                skippedFilesAppender.MaxSizeRollBackups = backups;
-                gsfLogAppender.MaxSizeRollBackups = backups;
-            }
-
             try
             {
-                void EnsureDirectory(string directory)
-                {
-                    if (!Directory.Exists(directory))
-                        Directory.CreateDirectory(directory);
-                }
+                CategorizedSettingsSection categorizedSettings = ConfigurationFile.Settings;
+                CategorizedSettingsElementCollection logSettings = categorizedSettings[settingsCategory];
+                logSettings.Add("LogPath", defaultPath, "Path to the log files produced by this log category.");
+                logSettings.Add("MaxSizeRollBackups", 10, "The maximum number of log files produced per day.");
+                logSettings.Add("MaximumFileSize", "1MB", "The maximum size of each log file produced. (Allowed suffixes: KB, MB, GB)");
 
-                void AssignFilePath(RollingFileAppender appender, string filePath)
-                {
-                    string directory = Path.GetDirectoryName(filePath);
-                    EnsureDirectory(directory);
-                    appender.File = filePath;
-                }
+                string logPath = logSettings["LogPath"].ValueAs(defaultPath);
+                string directory = Path.GetDirectoryName(logPath);
+                EnsureDirectory(directory);
 
-                AssignFilePath(debugLogAppender, @"Debug\openXDA\openXDA.log");
-                AssignFilePath(skippedFilesAppender, @"Debug\SkippedFiles\SkippedFiles.log");
-                AssignFilePath(gsfLogAppender, @"Debug\gsf\gsf.log");
+                RollingFileAppender rollingFileAppender = new RollingFileAppender();
+                rollingFileAppender.File = logPath;
+                rollingFileAppender.StaticLogFileName = false;
+                rollingFileAppender.AppendToFile = true;
+                rollingFileAppender.RollingStyle = RollingFileAppender.RollingMode.Composite;
+                rollingFileAppender.MaxSizeRollBackups = logSettings["MaxSizeRollBackups"].ValueAs(10);
+                rollingFileAppender.PreserveLogFileNameExtension = true;
+                rollingFileAppender.MaximumFileSize = logSettings["MaximumFileSize"].ValueAs("1MB");
+                rollingFileAppender.Layout = new PatternLayout("%date [%thread] %-5level %logger - %message%newline");
+                return rollingFileAppender;
             }
             catch (Exception ex)
             {
-                m_serviceHelper.ErrorLogger.Log(ex);
+                string message = $"Error occurred during initialization of log file \"{settingsCategory}\": {ex.Message}";
+                Exception wrapper = new Exception(message, ex);
+                m_serviceHelper.ErrorLogger.Log(wrapper);
+
+                RollingFileAppender rollingFileAppender = new RollingFileAppender();
+                rollingFileAppender.File = Path.GetFileName(defaultPath);
+                rollingFileAppender.StaticLogFileName = false;
+                rollingFileAppender.AppendToFile = true;
+                rollingFileAppender.RollingStyle = RollingFileAppender.RollingMode.Composite;
+                rollingFileAppender.MaxSizeRollBackups = 10;
+                rollingFileAppender.PreserveLogFileNameExtension = true;
+                rollingFileAppender.MaximumFileSize = "1MB";
+                rollingFileAppender.Layout = new PatternLayout("%date [%thread] %-5level %logger - %message%newline");
+
+                try
+                {
+                    string directory = Path.GetDirectoryName(defaultPath);
+                    EnsureDirectory(directory);
+                    rollingFileAppender.File = defaultPath;
+                }
+                catch
+                {
+#if DEBUG
+                    throw;
+#endif
+                }
+
+                return rollingFileAppender;
             }
+
+            void EnsureDirectory(string directory)
+            {
+                if (!Directory.Exists(directory))
+                    Directory.CreateDirectory(directory);
+            }
+        }
+
+        private void InitializeLogging()
+        {
+            ServiceHelperAppender serviceHelperAppender = new ServiceHelperAppender(m_serviceHelper);
+            RollingFileAppender debugLogAppender = InitializeRollingFileAppender("xdaDebugLog", @"Debug\openXDA\openXDA.log");
+            RollingFileAppender skippedFilesAppender = InitializeRollingFileAppender("skippedFilesLog", @"Debug\SkippedFiles\SkippedFiles.log");
+            RollingFileAppender gsfLogAppender = InitializeRollingFileAppender("gsfDebugLog", @"Debug\gsf\gsf.log");
+
+            debugLogAppender.AddFilter(new FileSkippedExceptionFilter());
+            skippedFilesAppender.AddFilter(new FileSkippedExceptionFilter(false));
 
             debugLogAppender.ActivateOptions();
             skippedFilesAppender.ActivateOptions();


### PR DESCRIPTION
Adds settings to the config file to control where debug log files are stored and how big they're allowed to get. This also removes the environment variables that controlled log file size, because those were made redundant and they couldn't be used to control individual log categories.