### PR TITLE
use configured time zone to timestamp data operation failures

### DIFF
--- a/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisNode.cs
@@ -328,13 +328,15 @@ namespace openXDA.Nodes.Types.Analysis
                     Exception wrapper = new Exception(message, ex);
                     if (status == FileGroupProcessingStatus.Success) status = FileGroupProcessingStatus.PartialSuccess;
                     Log.Error(wrapper.Message, wrapper);
+                    Action<object> configurator = GetConfigurator();
+                    TimeZoneConverter timeZoneConverter = new TimeZoneConverter(configurator);
                     dataOperationFailures.Add(new DataOperationFailure
                     {
                         DataOperationID = dataOperationDefinition.ID,
                         FileGroupID = meterDataSet.FileGroup.ID,
                         Log = message,
                         StackTrace = ex.StackTrace,
-                        TimeOfFailure = DateTime.UtcNow
+                        TimeOfFailure = timeZoneConverter.ToXDATimeZone(DateTime.UtcNow)
                     });
                     if (IsDisposed)
                     {


### PR DESCRIPTION
Per XDA-69, changes `DataOperationFailure.TimeOfFailure` to use configured timezone, like the rest of the timestamps involved in data operations.