### PR TITLE
Use credentials in Structure Query and add endpoint for testing it

### DIFF
--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -151,7 +151,7 @@ namespace openXDA.Controllers.Config
 
             string query = @"
                 SELECT TOP (1) *,
-                (SELECT assetLocation.LocationID FROM AssetLocation assetLocation WHERE assetLocation.AssetID = ID) AS LocationID
+                (SELECT assetLocation.LocationID FROM AssetLocation assetLocation WHERE assetLocation.AssetID = asset.ID) AS LocationID
                 FROM Asset asset
                     WHERE AssetTypeID = 1
             ";
@@ -163,7 +163,7 @@ namespace openXDA.Controllers.Config
                 if (result.Rows.Count == 0)
                     return Ok(status);
 
-                if (string.IsNullOrEmpty(result.Rows[0].Field<string>("LocationID")) || string.IsNullOrEmpty(result.Rows[0].Field<string>("AssetKey")))
+                if (result.Rows[0].IsNull("LocationID") || result.Rows[0].IsNull("AssetKey"))
                     return Ok(status);
 
                 stationKey = result.Rows[0].Field<int>("LocationID");

--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -146,13 +146,14 @@ namespace openXDA.Controllers.Config
             if (!settings.StructureQuerySettings.Enabled)
                 return Ok(status);
 
-            int stationKey;
+            string stationKey;
             string lineKey;
 
             string query = @"
-                SELECT TOP (1) *,
-                (SELECT TOP (1) assetLocation.LocationID FROM AssetLocation assetLocation WHERE assetLocation.AssetID = asset.ID) AS LocationID
+                SELECT TOP (1) *
                 FROM Asset asset
+	                INNER JOIN AssetLocation ON AssetLocation.AssetID = Asset.ID
+	                INNER JOIN Location ON AssetLocation.LocationID = Location.ID
                     WHERE AssetTypeID = 1
             ";
 
@@ -166,7 +167,7 @@ namespace openXDA.Controllers.Config
                 if (result.Rows[0].IsNull("LocationID") || result.Rows[0].IsNull("AssetKey"))
                     return Ok(status);
 
-                stationKey = result.Rows[0].Field<int>("LocationID");
+                stationKey = result.Rows[0].Field<string>("LocationKey");
                 lineKey = result.Rows[0].Field<string>("AssetKey");
             }
             try

--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -130,13 +130,13 @@ namespace openXDA.Controllers.Config
             return Ok(scadaDataResource.GetHistorianHealth());
         }
 
-        [Route("MaximoStructureQuery/Health")]
-        public IHttpActionResult GetMaximoStructureQueryHealth()
+        [Route("StructureCrawler/Health")]
+        public IHttpActionResult GetStructureCrawlerHealth()
         {
             Settings settings = new Settings();
             GetConfigurator()(settings);
 
-            AppStatus maximoStructureQueryStatus = new AppStatus()
+            AppStatus status = new AppStatus()
             {
                 Status = "Error",
                 Details = new List<StatusItem>()
@@ -168,23 +168,23 @@ namespace openXDA.Controllers.Config
                 }
 
                 GetStructureInfo(url, credentials);
-                maximoStructureQueryStatus.Status = "Success";
-                maximoStructureQueryStatus.Details.Add(new StatusItem() { Status = "Success", Description = "Successful response received from Maximo Structure Query." });
+                status.Status = "Success";
+                status.Details.Add(new StatusItem() { Status = "Success", Description = "Successful response received from Structure Crawler." });
             }
             catch(Exception ex)
             {
                 if (ex is HttpRequestException httpRequestException)
-                    maximoStructureQueryStatus.Details.Add(new StatusItem() { Status = "Error", Description = httpRequestException.Message });
+                    status.Details.Add(new StatusItem() { Status = "Error", Description = httpRequestException.Message });
                 else if (ex is UriFormatException uriFormatException)
-                    maximoStructureQueryStatus.Details.Add(new StatusItem() { Status = "Error", Description = "Url formatting failed. Check StructureQuery.URLFormat in openXDA settings." });
+                    status.Details.Add(new StatusItem() { Status = "Error", Description = "Url formatting failed. Check StructureQuery.URLFormat in openXDA settings." });
                 else
                 {
-                    Log.Error($"Unexpected exception thrown during Maximo Structure Query.", ex);
-                    maximoStructureQueryStatus.Details.Add(new StatusItem() { Status = "Error", Description = "Unexpected exception thrown after receiving Maximo Structure Query. Full exception message is available in openXDA logs." });
+                    Log.Error($"Unexpected exception thrown during Structure Crawler Query.", ex);
+                    status.Details.Add(new StatusItem() { Status = "Error", Description = "Unexpected exception thrown during Structure Crawler query. Full exception message is available in openXDA logs." });
                 }
             }
 
-            return Ok(maximoStructureQueryStatus);
+            return Ok(status);
         }
 
         private Action<object> GetConfigurator()

--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -134,17 +134,17 @@ namespace openXDA.Controllers.Config
         [Route("StructureCrawler/Health")]
         public IHttpActionResult GetStructureCrawlerHealth()
         {
+
+            AppStatus status = new AppStatus()
+            {
+                Status = "N/A"
+            };
+
             Settings settings = new Settings();
             GetConfigurator()(settings);
 
             if (!settings.StructureQuerySettings.Enabled)
-                return Ok(new AppStatus() { Status = "N/A"});
-
-            AppStatus status = new AppStatus()
-            {
-                Status = "Error",
-                Details = new List<StatusItem>()
-            };
+                return Ok(status);
 
             int stationKey;
             string lineKey;
@@ -159,10 +159,13 @@ namespace openXDA.Controllers.Config
             using (AdoDataConnection connection = CreateDbConnection())
             {
                 DataTable result = connection.RetrieveData(query);
+
+                if (result.Rows.Count == 0)
+                    return Ok(status);
+
                 stationKey = result.Rows[0].Field<int>("LocationID");
                 lineKey = result.Rows[0].Field<string>("AssetKey");
             }
-
             try
             {
                 string url = string.Format(settings.StructureQuerySettings.URLFormat, stationKey, lineKey, 1);
@@ -182,6 +185,7 @@ namespace openXDA.Controllers.Config
             }
             catch(Exception ex)
             {
+                status.Status = "Error";
                 if (ex is HttpRequestException httpRequestException)
                     status.Details.Add(new StatusItem() { Status = "Error", Description = httpRequestException.Message });
                 else if (ex is UriFormatException uriFormatException)

--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -23,20 +23,39 @@
 
 using FaultData.DataResources;
 using FaultData.DataSets;
+using GSF.Configuration;
 using GSF.Data;
+using GSF.Data.Model;
 using log4net;
 using Newtonsoft.Json.Linq;
+using openXDA.Model;
+using openXDA.Model.SystemCenter;
 using openXDA.Nodes;
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
+using static FaultData.DataOperations.TVA.StructureQueryOperation;
+using ConfigurationLoader = openXDA.Nodes.ConfigurationLoader;
 
 namespace openXDA.Controllers.Config
 {
     [RoutePrefix("api/SystemCenter")]
     public class SystemCenterController : ApiController
     {
+        #region [ Members ]
+        private class Settings
+        {
+            [Category]
+            [SettingName(StructureQuerySection.CategoryName)]
+            public StructureQuerySection StructureQuerySettings { get; } = new StructureQuerySection();
+        }
+        #endregion
+
         #region [ Constructors ]
 
         public SystemCenterController(Host nodeHost)
@@ -109,6 +128,63 @@ namespace openXDA.Controllers.Config
             SCADADataResource scadaDataResource = meterDataSet.GetResource<SCADADataResource>();
             scadaDataResource.Initialize(meterDataSet);
             return Ok(scadaDataResource.GetHistorianHealth());
+        }
+
+        [Route("MaximoStructureQuery/Health")]
+        public IHttpActionResult GetMaximoStructureQueryHealth()
+        {
+            Settings settings = new Settings();
+            GetConfigurator()(settings);
+
+            AppStatus maximoStructureQueryStatus = new AppStatus()
+            {
+                Status = "Error",
+                Details = new List<StatusItem>()
+            };
+
+            string stationKey;
+            string lineKey;
+
+            using (AdoDataConnection connection = CreateDbConnection())
+            {
+                TableOperations<Meter> meterTable = new TableOperations<Meter>(connection);
+                Meter testMeter = meterTable.QueryRecord(new RecordRestriction("0 NOT LIKE {0}", "ID"));
+                stationKey = testMeter.LocationID.ToString();
+                lineKey = testMeter.AssetKey.ToString();
+            }
+
+            try
+            {
+                // we can pick any meter for their station key and asset key. distance i'm not sure about.
+                string url = string.Format(settings.StructureQuerySettings.URLFormat, stationKey, lineKey, "dummy");
+
+                ICredentials credentials = null;
+                if (settings.StructureQuerySettings.UserName != null && settings.StructureQuerySettings.Password != null && settings.StructureQuerySettings.Domain != null)
+                {
+                    NetworkCredential networkCredential = new NetworkCredential(settings.StructureQuerySettings.UserName, settings.StructureQuerySettings.Password, settings.StructureQuerySettings.Domain);
+                    CredentialCache cache = new CredentialCache();
+                    cache.Add(new Uri(url), "NTLM", networkCredential);
+                    credentials = cache;
+                }
+
+                GetStructureInfo(url, credentials);
+                maximoStructureQueryStatus.Status = "Success";
+                maximoStructureQueryStatus.Details.Add(new StatusItem() { Status = "Success", Description = "Successful response received from Maximo Structure Query." });
+            }
+            catch(Exception ex)
+            {
+                if (ex is HttpRequestException httpRequestException)
+                    maximoStructureQueryStatus.Details.Add(new StatusItem() { Status = "Error", Description = httpRequestException.Message });
+                else if (ex is UriFormatException uriFormatException)
+                    maximoStructureQueryStatus.Details.Add(new StatusItem() { Status = "Error", Description = "Url formatting failed. Check StructureQuery.URLFormat in openXDA settings." });
+                else
+                {
+                    Log.Error($"Unexpected exception thrown during Maximo Structure Query.", ex);
+                    maximoStructureQueryStatus.Details.Add(new StatusItem() { Status = "Error", Description = "Unexpected exception thrown after receiving Maximo Structure Query. Full exception message is available in openXDA logs." });
+                }
+            }
+
+            return Ok(maximoStructureQueryStatus);
         }
 
         private Action<object> GetConfigurator()

--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -163,6 +163,9 @@ namespace openXDA.Controllers.Config
                 if (result.Rows.Count == 0)
                     return Ok(status);
 
+                if (string.IsNullOrEmpty(result.Rows[0].Field<string>("LocationID")) || string.IsNullOrEmpty(result.Rows[0].Field<string>("AssetKey")))
+                    return Ok(status);
+
                 stationKey = result.Rows[0].Field<int>("LocationID");
                 lineKey = result.Rows[0].Field<string>("AssetKey");
             }

--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -198,7 +198,6 @@ namespace openXDA.Controllers.Config
                     status.Details.Add(new StatusItem() { Status = "Error", Description = "Failed to authorize structure query. Check the StructureQuery.UserName and StructureQuery.Password in openXDA settings." });
                 else
                 {
-                    Log.Error($"Unexpected exception thrown during Structure Crawler Query.", ex);
                     status.Details.Add(new StatusItem() { Status = "Error", Description = "Unexpected exception thrown during Structure Crawler query. Full exception message is available in openXDA logs." });
                 }
             }

--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -151,7 +151,7 @@ namespace openXDA.Controllers.Config
 
             string query = @"
                 SELECT TOP (1) *,
-                (SELECT assetLocation.LocationID FROM AssetLocation assetLocation WHERE assetLocation.AssetID = asset.ID) AS LocationID
+                (SELECT TOP (1) assetLocation.LocationID FROM AssetLocation assetLocation WHERE assetLocation.AssetID = asset.ID) AS LocationID
                 FROM Asset asset
                     WHERE AssetTypeID = 1
             ";

--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -151,10 +151,10 @@ namespace openXDA.Controllers.Config
 
             using (AdoDataConnection connection = CreateDbConnection())
             {
-                int assetID = connection.ExecuteScalar<int>(@"SELECT TOP (1) ID FROM Asset WHERE AssetTypeID = 1");
-                int locationID = connection.ExecuteScalar<int>(@"SELECT TOP (1) LocationID From AssetLocation WHERE AssetID = {0}", assetID);
-                lineKey = connection.ExecuteScalar<string>(@"SELECT AssetKey FROM Asset WHERE ID = {0}", assetID);
-                stationKey = connection.ExecuteScalar<string>(@"SELECT LocationKey FROM Location WHERE ID = {0}", locationID);
+                int assetID = connection.ExecuteScalar<int>("SELECT TOP (1) ID FROM Asset WHERE AssetTypeID = 1");
+                int locationID = connection.ExecuteScalar<int>("SELECT TOP (1) LocationID From AssetLocation WHERE AssetID = {0}", assetID);
+                lineKey = connection.ExecuteScalar<string>("SELECT AssetKey FROM Asset WHERE ID = {0}", assetID);
+                stationKey = connection.ExecuteScalar<string>("SELECT LocationKey FROM Location WHERE ID = {0}", locationID);
             }
 
             if (String.IsNullOrEmpty(lineKey) || String.IsNullOrEmpty(stationKey))

--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -190,9 +190,11 @@ namespace openXDA.Controllers.Config
             {
                 status.Status = "Error";
                 if (ex is HttpRequestException httpRequestException)
-                    status.Details.Add(new StatusItem() { Status = "Error", Description = httpRequestException.Message });
+                    status.Details.Add(new StatusItem() { Status = "Error", Description = "Structure query received invalid response. Check the logs for full details." });
                 else if (ex is UriFormatException uriFormatException)
                     status.Details.Add(new StatusItem() { Status = "Error", Description = "Url formatting failed. Check StructureQuery.URLFormat in openXDA settings." });
+                else if (ex is UnauthorizedAccessException)
+                    status.Details.Add(new StatusItem() { Status = "Error", Description = "Failed to authorize structure query. Check the StructureQuery.UserName and StructureQuery.Password in openXDA settings." });
                 else
                 {
                     Log.Error($"Unexpected exception thrown during Structure Crawler Query.", ex);

--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -34,6 +34,7 @@ using openXDA.Nodes;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Data;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -136,27 +137,35 @@ namespace openXDA.Controllers.Config
             Settings settings = new Settings();
             GetConfigurator()(settings);
 
+            if (!settings.StructureQuerySettings.Enabled)
+                return Ok(new AppStatus() { Status = "N/A"});
+
             AppStatus status = new AppStatus()
             {
                 Status = "Error",
                 Details = new List<StatusItem>()
             };
 
-            string stationKey;
+            int stationKey;
             string lineKey;
+
+            string query = @"
+                SELECT TOP (1) *,
+                (SELECT assetLocation.LocationID FROM AssetLocation assetLocation WHERE assetLocation.AssetID = ID) AS LocationID
+                FROM Asset asset
+                    WHERE AssetTypeID = 1
+            ";
 
             using (AdoDataConnection connection = CreateDbConnection())
             {
-                TableOperations<Meter> meterTable = new TableOperations<Meter>(connection);
-                Meter testMeter = meterTable.QueryRecord(new RecordRestriction("0 NOT LIKE {0}", "ID"));
-                stationKey = testMeter.LocationID.ToString();
-                lineKey = testMeter.AssetKey.ToString();
+                DataTable result = connection.RetrieveData(query);
+                stationKey = result.Rows[0].Field<int>("LocationID");
+                lineKey = result.Rows[0].Field<string>("AssetKey");
             }
 
             try
             {
-                // we can pick any meter for their station key and asset key. distance i'm not sure about.
-                string url = string.Format(settings.StructureQuerySettings.URLFormat, stationKey, lineKey, "dummy");
+                string url = string.Format(settings.StructureQuerySettings.URLFormat, stationKey, lineKey, 1);
 
                 ICredentials credentials = null;
                 if (settings.StructureQuerySettings.UserName != null && settings.StructureQuerySettings.Password != null && settings.StructureQuerySettings.Domain != null)

--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -149,27 +149,17 @@ namespace openXDA.Controllers.Config
             string stationKey;
             string lineKey;
 
-            string query = @"
-                SELECT TOP (1) *
-                FROM Asset asset
-	                INNER JOIN AssetLocation ON AssetLocation.AssetID = Asset.ID
-	                INNER JOIN Location ON AssetLocation.LocationID = Location.ID
-                    WHERE AssetTypeID = 1
-            ";
-
             using (AdoDataConnection connection = CreateDbConnection())
             {
-                DataTable result = connection.RetrieveData(query);
-
-                if (result.Rows.Count == 0)
-                    return Ok(status);
-
-                if (result.Rows[0].IsNull("LocationID") || result.Rows[0].IsNull("AssetKey"))
-                    return Ok(status);
-
-                stationKey = result.Rows[0].Field<string>("LocationKey");
-                lineKey = result.Rows[0].Field<string>("AssetKey");
+                int assetID = connection.ExecuteScalar<int>(@"SELECT TOP (1) ID FROM Asset WHERE AssetTypeID = 1");
+                int locationID = connection.ExecuteScalar<int>(@"SELECT TOP (1) LocationID From AssetLocation WHERE AssetID = {0}", assetID);
+                lineKey = connection.ExecuteScalar<string>(@"SELECT AssetKey FROM Asset WHERE ID = {0}", assetID);
+                stationKey = connection.ExecuteScalar<string>(@"SELECT LocationKey FROM Location WHERE ID = {0}", locationID);
             }
+
+            if (String.IsNullOrEmpty(lineKey) || String.IsNullOrEmpty(stationKey))
+                    return Ok(status);
+
             try
             {
                 string url = string.Format(settings.StructureQuerySettings.URLFormat, stationKey, lineKey, 1);

--- a/Source/Libraries/FaultData/DataOperations/TVA/StructureQueryOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/TVA/StructureQueryOperation.cs
@@ -35,7 +35,9 @@ using GSF.Configuration;
 using GSF.Data;
 using GSF.Data.Model;
 using HtmlAgilityPack;
+using log4net;
 using openXDA.Model;
+using System.Net.Http;
 
 namespace FaultData.DataOperations.TVA
 {
@@ -55,6 +57,22 @@ namespace FaultData.DataOperations.TVA
             [Setting]
             [DefaultValue("StrNumber:AssetKey,Latitude:Latitude,Longitude:Longitude")]
             public string FieldMappings { get; set; }
+
+            [Setting]
+            [DefaultValue("")]
+            public string UserName { get; set; }
+
+            [Setting]
+            [DefaultValue("")]
+            public string Password { get; set; }
+
+            [Setting]
+            [DefaultValue("")]
+            public string Domain { get; set; }
+
+            [Setting]
+            [DefaultValue(false)]
+            public bool Enabled { get; set; } = false;
         }
 
         // Constants
@@ -94,6 +112,12 @@ namespace FaultData.DataOperations.TVA
 
         public override void Execute(MeterDataSet meterDataSet)
         {
+            if (!Settings.Enabled)
+            {
+                Log.Warn("Structure Query Operation is not enabled.");
+                return;
+            }
+
             FaultDataResource faultDataResource = meterDataSet.GetResource<FaultDataResource>();
             string stationKey = meterDataSet.Meter.Location.LocationKey;
 
@@ -121,7 +145,18 @@ namespace FaultData.DataOperations.TVA
                         return;
 
                     string url = string.Format(Settings.URLFormat, stationKey, lineKey, distance);
-                    string structureInfo = GetStructureInfo(url);
+
+                    ICredentials credentials = null;
+                    if (Settings.UserName != null && Settings.Password != null && Settings.Domain != null)
+                    {
+                        NetworkCredential networkCredential = new NetworkCredential(Settings.UserName, Settings.Password, Settings.Domain);
+                        CredentialCache cache = new CredentialCache();
+                        cache.Add(new Uri(url), "NTLM", networkCredential);
+                        credentials = cache;
+                    }
+
+                    string structureInfo = GetStructureInfo(url, credentials);
+
                     DataTable structureData = ToDataTable(structureInfo);
 
                     if (structureData.Rows.Count == 0)
@@ -178,19 +213,39 @@ namespace FaultData.DataOperations.TVA
                 }
             }
         }
-
-        private static string GetStructureInfo(string url)
+        public static string GetStructureInfo(string url, ICredentials credentials = null)
         {
-            bool HandlePreRequest(HttpWebRequest request)
-            {
-                request.UseDefaultCredentials = true;
-                return true;
+            HttpClientHandler handler;
+
+            if (credentials is null)
+                handler = new HttpClientHandler() { UseDefaultCredentials = true };
+            else
+                handler = new HttpClientHandler() { Credentials = credentials };
+
+            HttpClient client = new HttpClient(handler);
+            string html;
+            HttpResponseMessage response = client.GetAsync(url).GetAwaiter().GetResult();
+
+            if (response.StatusCode is HttpStatusCode.Forbidden)
+        {
+                string responseContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                Log.Error($"Structure query received 'Forbidden' response: {responseContent}");
+                throw new HttpRequestException($"Failed to authorize structured query. Check the StructureQuery.UserName and StructureQuery.Password in openXDA settings.");
             }
 
-            HtmlWeb webClient = new HtmlWeb();
-            webClient.PreRequest += HandlePreRequest;
-            HtmlDocument doc = webClient.Load(url);
-            return doc.DocumentNode.InnerText.Trim();
+            if (response.StatusCode is HttpStatusCode.InternalServerError)
+            {
+                string responseContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                Log.Error($"Structure query received 'InternalServerError' response: {responseContent}");
+                throw new HttpRequestException($"Structure query failed due to internal server error. Full error message is available in openXDA logs.");
+            }
+
+            html = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            HtmlDocument doc = new HtmlDocument();
+            doc.LoadHtml(html);
+
+            string result = doc.DocumentNode.Descendants("html").FirstOrDefault().InnerText.Trim();
+            return result;
         }
 
         private DataTable ToDataTable(string csvInput)
@@ -223,6 +278,13 @@ namespace FaultData.DataOperations.TVA
             double.TryParse(csvValue, out double num)
                 ? num
                 : 0.0D;
+
+        #endregion
+
+        #region [ Static ]
+
+        // Static Fields
+        private static readonly ILog Log = LogManager.GetLogger(typeof(StructureQueryOperation));
 
         #endregion
     }

--- a/Source/Libraries/FaultData/DataOperations/TVA/StructureQueryOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/TVA/StructureQueryOperation.cs
@@ -229,16 +229,16 @@ namespace FaultData.DataOperations.TVA
             if (response.StatusCode is HttpStatusCode.Forbidden)
         {
                 string responseContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                Log.Error($"Structure query received 'Forbidden' response: {responseContent}");
-                throw new HttpRequestException($"Failed to authorize structure query. Check the StructureQuery.UserName and StructureQuery.Password in openXDA settings.");
+                throw new HttpRequestException($"Structure query received 'Forbidden' response: {responseContent}");
             }
 
             if (response.StatusCode is HttpStatusCode.InternalServerError)
             {
                 string responseContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                Log.Error($"Structure query received 'InternalServerError' response: {responseContent}");
-                throw new HttpRequestException($"Structure query failed due to internal server error. Full error message is available in openXDA logs.");
+                throw new HttpRequestException($"Structure query received 'InternalServerError' response: {responseContent}");
             }
+
+            response.EnsureSuccessStatusCode();
 
             html = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             HtmlDocument doc = new HtmlDocument();

--- a/Source/Libraries/FaultData/DataOperations/TVA/StructureQueryOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/TVA/StructureQueryOperation.cs
@@ -230,7 +230,7 @@ namespace FaultData.DataOperations.TVA
         {
                 string responseContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
                 Log.Error($"Structure query received 'Forbidden' response: {responseContent}");
-                throw new HttpRequestException($"Failed to authorize structured query. Check the StructureQuery.UserName and StructureQuery.Password in openXDA settings.");
+                throw new HttpRequestException($"Failed to authorize structure query. Check the StructureQuery.UserName and StructureQuery.Password in openXDA settings.");
             }
 
             if (response.StatusCode is HttpStatusCode.InternalServerError)


### PR DESCRIPTION
For XDA-69 - previous method of sending a structure query and processing the response did not throw an exception for unsuccessful HTTP responses, and would attempt to read unsuccessful responses as CSV. Now that credentials are being used, `GetStructureQuery` is changed to use configurable credentials and check for successful response before parsing the response. 

An endpoint is added as well to check the success of Structure Queries through System Center.  