### PR TITLE
Fix broken query

### DIFF
--- a/Source/Libraries/openXDA.Model/SystemCenter/ValueList.cs
+++ b/Source/Libraries/openXDA.Model/SystemCenter/ValueList.cs
@@ -217,7 +217,7 @@ namespace SystemCenter.Model
                 else
                     return new List<ValueList>();
             }
-            return valueTable.QueryRecordsWhere("GroupID in ({0})", string.Join(", ", groupIds)).OrderBy(v => v.SortOrder);
+            return valueTable.QueryRecordsWhere($"GroupID in ({string.Join(",", groupIds)})").OrderBy(v => v.SortOrder);
         }
 
         private int GetCount(string groupName, string value, AdoDataConnection connection)


### PR DESCRIPTION
This substitution fails because the parameter in the `0` substitution should be int. interpolating it into the string is fine.