### PR TITLE
Initialize configuration file before logging

### DIFF
--- a/Source/Applications/openXDA/openXDA/ServiceHost.cs
+++ b/Source/Applications/openXDA/openXDA/ServiceHost.cs
@@ -182,10 +182,9 @@ namespace openXDA
             // Set current working directory to fix relative paths
             Directory.SetCurrentDirectory(FilePath.GetAbsolutePath(""));
 
-            InitializeLogging();
-
             ConfigurationFile = ConfigurationFile.Current;
             InitializeConfigurationFile();
+            InitializeLogging();
 
             DatabaseConnectionFactory = new DatabaseConnectionFactory(ConfigurationFile);
 


### PR DESCRIPTION
Fixes a `NullReferenceException` because--as of #626--logging now depends on the config file so the order in which they are initialized needs to change.