### PR TITLE
XDA-87 Structure crawler fix

### DIFF
--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -137,7 +137,8 @@ namespace openXDA.Controllers.Config
 
             AppStatus status = new AppStatus()
             {
-                Status = "N/A"
+                Status = "N/A",
+                Details = new List<StatusItem>()
             };
 
             Settings settings = new Settings();

--- a/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/openXDA/openXDA/Controllers/SystemCenter/SystemCenterController.cs
@@ -149,6 +149,7 @@ namespace openXDA.Controllers.Config
 
             string stationKey;
             string lineKey;
+            int halfLength;
 
             using (AdoDataConnection connection = CreateDbConnection())
             {
@@ -156,14 +157,17 @@ namespace openXDA.Controllers.Config
                 int locationID = connection.ExecuteScalar<int>("SELECT TOP (1) LocationID From AssetLocation WHERE AssetID = {0}", assetID);
                 lineKey = connection.ExecuteScalar<string>("SELECT AssetKey FROM Asset WHERE ID = {0}", assetID);
                 stationKey = connection.ExecuteScalar<string>("SELECT LocationKey FROM Location WHERE ID = {0}", locationID);
-            }
 
             if (String.IsNullOrEmpty(lineKey) || String.IsNullOrEmpty(stationKey))
                     return Ok(status);
 
+                int lineLength = connection.ExecuteScalar<int>("SELECT TOP (1) Length FROM LineView WHERE AssetKey = {0}", lineKey);
+                halfLength = lineLength / 2;
+            }
+
             try
             {
-                string url = string.Format(settings.StructureQuerySettings.URLFormat, stationKey, lineKey, 1);
+                string url = string.Format(settings.StructureQuerySettings.URLFormat, stationKey, lineKey, halfLength);
 
                 ICredentials credentials = null;
                 if (settings.StructureQuerySettings.UserName != null && settings.StructureQuerySettings.Password != null && settings.StructureQuerySettings.Domain != null)


### PR DESCRIPTION
Per XDA-87, corrects instantiation of the `AppStatus` object to prevent null reference errors when adding `Details`, and calculates a distance argument based on line length rather than a constant 1.