### PR TITLE
Add FileWatcher.HighPriorityPaths setting

### DIFF
--- a/Source/Libraries/openXDA.Configuration/FileWatcherSection.cs
+++ b/Source/Libraries/openXDA.Configuration/FileWatcherSection.cs
@@ -256,6 +256,24 @@ namespace openXDA.Configuration
         private List<FileShare> _FileShareList { get; set; }
 
         /// <summary>
+        /// Gets or sets a semicolon-separated list of patterns for
+        /// matching file paths which should be given higher priority.
+        /// </summary>
+        [Setting]
+        [DefaultValue("")]
+        public string HighPriorityPaths { get; set; }
+
+        /// <summary>
+        /// Gets a list of patterns for matching file paths which should be given higher priority.
+        /// </summary>
+        public string[] HighPriorityPathList => HighPriorityPaths
+            .ToNonNullString()
+            .Split(Path.PathSeparator)
+            .Select(path => path.Trim())
+            .Where(path => !string.IsNullOrEmpty(path))
+            .ToArray();
+
+        /// <summary>
         /// Gets or sets the number of threads used
         /// internally to the file processor.
         /// </summary>

--- a/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisTask.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/Analysis/AnalysisTask.cs
@@ -46,7 +46,8 @@ namespace openXDA.Nodes.Types.Analysis
         public int Priority { get; }
 
         public const int FileEnumerationPriority = 1;
-        public const int FileWatcherPriority = 2;
-        public const int RequeuePriority = 3;
+        public const int NormalFileWatcherPriority = 2;
+        public const int HighFileWatcherPriority = 3;
+        public const int RequeuePriority = 4;
     }
 }

--- a/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileProcessorNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileProcessorNode.cs
@@ -166,6 +166,7 @@ namespace openXDA.Nodes.Types.FileProcessing
 
         private string Filter { get; set; }
         private int ProcessingThreadCount { get; set; }
+        private string[] HighPriorityPaths { get; set; }
         private IEnumerable<FileShare> FileShares { get; set; }
 
         private FileProcessorIndex FileProcessorIndex
@@ -408,6 +409,7 @@ namespace openXDA.Nodes.Types.FileProcessing
             Settings settings = new Settings(configurator);
             Filter = QueryFilter();
             ProcessingThreadCount = settings.FileProcessorSettings.ProcessingThreadCount;
+            HighPriorityPaths = settings.FileWatcherSettings.HighPriorityPathList;
             AuthenticateFileShares(settings);
             ConfigureFileProcessor(settings);
         }
@@ -463,6 +465,13 @@ namespace openXDA.Nodes.Types.FileProcessing
         {
             string[] filters = Filter.Split(Path.PathSeparator);
             return FilePath.IsFilePatternMatch(filters, filePath, true);
+        }
+
+        private int GetFileWatcherPriority(string filePath)
+        {
+            return FilePath.IsFilePatternMatch(HighPriorityPaths, filePath, true)
+                ? AnalysisTask.HighFileWatcherPriority
+                : AnalysisTask.NormalFileWatcherPriority;
         }
 
         private async Task NotifyAnalysisNodesAsync()
@@ -606,7 +615,7 @@ namespace openXDA.Nodes.Types.FileProcessing
             }
 
             int priority = fileProcessorEventArgs.RaisedByFileWatcher
-                ? AnalysisTask.FileWatcherPriority
+                ? GetFileWatcherPriority(filePath)
                 : AnalysisTask.FileEnumerationPriority;
 
             WorkItem workItem = new WorkItem(fileGroupInfo, filePath, priority);


### PR DESCRIPTION
This PR adds a `FileWatcher.HighPriorityPaths` setting so that the user can specify a list of patterns by which to match files picked up by the file watcher. Files that match this pattern would be prioritized higher compared to files that don't. This doesn't apply to files picked up by file enumeration, including those that would be picked up automatically due to the `Too many changes in directory` error.

File patterns are wildcard expressions.
* `**\` matches folders recursively
* `*` matches one or more characters that are not directory separators
* `?` matches one character which is not a directory separator

The setting is a semicolon-separated list of these wildcard patterns.