### PR TITLE
XDA-65 Fix phase angle computation in Transform.ToCycleDataGroup()

### DIFF
--- a/Source/Libraries/FaultData/DataAnalysis/Transform.cs
+++ b/Source/Libraries/FaultData/DataAnalysis/Transform.cs
@@ -91,7 +91,7 @@ namespace FaultData.DataAnalysis
 
             void CaptureCycle(int cycleIndex)
             {
-                DateTime startTime = dataSeries.DataPoints[0].Time;
+                DateTime startTime = dataSeries.DataPoints[cycleIndex].Time;
 
                 for (int i = 0; i < samplesPerCycle; i++)
                 {

--- a/Source/Libraries/openXDA.XMLConfigLoader/Loader.cs
+++ b/Source/Libraries/openXDA.XMLConfigLoader/Loader.cs
@@ -195,7 +195,7 @@ namespace openXDA.XMLConfig
                                 }
                                 // Load Line Sements links
                                 foreach (XmlNode lineSegmentNode in assetNode.SelectNodes("Segment"))
-                                    foreach (XmlNode childSegmentNode in assetNode.SelectNodes("ChildSegment"))
+                                    foreach (XmlNode childSegmentNode in lineSegmentNode.SelectNodes("ChildSegment"))
                                         LinkLineSegments(lineSegmentNode, childSegmentNode);
                                 break;
 

--- a/Source/Libraries/openXDA.XMLConfigLoader/Loader.cs
+++ b/Source/Libraries/openXDA.XMLConfigLoader/Loader.cs
@@ -847,7 +847,7 @@ namespace openXDA.XMLConfig
                     AssetID = assetID,
                     Name = channelNode.Attributes["Name"].Value,
                     Description = channelNode.Attributes["Description"]?.Value,
-                    Enabled = (channelNode.Attributes["Enabled"]?.Value ?? "1") == "1",
+                    Enabled = channelNode.Attributes["Enabled"]?.Value.ParseBoolean() ?? true,
                     SamplesPerHour = double.Parse(channelNode.Attributes["SamplesPerHour"]?.Value ?? "0.0"),
                     Adder = double.Parse(channelNode.Attributes["Adder"]?.Value ?? "0.0"),
                     Multiplier = double.Parse(channelNode.Attributes["Multiplier"]?.Value ?? "1.0"),

--- a/Source/Libraries/openXDA.XMLConfigLoader/Loader.cs
+++ b/Source/Libraries/openXDA.XMLConfigLoader/Loader.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using System.Xml;
+using GSF;
 using GSF.Data;
 using GSF.Data.Model;
 using log4net;
@@ -317,8 +318,8 @@ namespace openXDA.XMLConfig
             {
                 AssetKey = assetNode.Attributes["AssetKey"].Value,
                 AssetName = assetNode.Attributes["AssetName"].Value,
-                VoltageKV = float.Parse(assetNode.Attributes["Make"]?.Value ?? "0.0"),
-                Spare = (assetNode.Attributes["Model"]?.Value ?? "0") == "1",
+                VoltageKV = double.Parse(assetNode.Attributes["VoltageKV"]?.Value ?? "0.0"),
+                Spare = assetNode.Attributes["Spare"]?.Value.ParseBoolean() ?? false,
                 Description = assetNode.Attributes["Description"]?.Value
             };
 
@@ -351,8 +352,8 @@ namespace openXDA.XMLConfig
             {
                 AssetKey = assetNode.Attributes["AssetKey"].Value,
                 AssetName = assetNode.Attributes["AssetName"].Value,
-                VoltageKV = float.Parse(assetNode.Attributes["Make"]?.Value ?? "0.0"),
-                Spare = (assetNode.Attributes["Model"]?.Value ?? "0") == "1",
+                VoltageKV = double.Parse(assetNode.Attributes["VoltageKV"]?.Value ?? "0.0"),
+                Spare = assetNode.Attributes["Spare"]?.Value.ParseBoolean() ?? false,
                 Description = assetNode.Attributes["Description"]?.Value
             };
 
@@ -385,8 +386,8 @@ namespace openXDA.XMLConfig
             {
                 AssetKey = assetNode.Attributes["AssetKey"].Value,
                 AssetName = assetNode.Attributes["AssetName"].Value,
-                VoltageKV = float.Parse(assetNode.Attributes["Make"]?.Value ?? "0.0"),
-                Spare = (assetNode.Attributes["Model"]?.Value ?? "0") == "1",
+                VoltageKV = double.Parse(assetNode.Attributes["VoltageKV"]?.Value ?? "0.0"),
+                Spare = assetNode.Attributes["Spare"]?.Value.ParseBoolean() ?? false,
                 Description = assetNode.Attributes["Description"]?.Value
             };
 
@@ -418,8 +419,8 @@ namespace openXDA.XMLConfig
             {
                 AssetKey = assetNode.Attributes["AssetKey"].Value,
                 AssetName = assetNode.Attributes["AssetName"].Value,
-                VoltageKV = float.Parse(assetNode.Attributes["Make"]?.Value ?? "0.0"),
-                Spare = (assetNode.Attributes["Model"]?.Value ?? "0") == "1",
+                VoltageKV = double.Parse(assetNode.Attributes["VoltageKV"]?.Value ?? "0.0"),
+                Spare = assetNode.Attributes["Spare"]?.Value.ParseBoolean() ?? false,
                 Description = assetNode.Attributes["Description"]?.Value
             };
 
@@ -465,8 +466,8 @@ namespace openXDA.XMLConfig
                 }
 
                 record.AssetName = assetNode.Attributes["AssetName"].Value;
-                record.VoltageKV = double.Parse(assetNode.Attributes["Make"]?.Value ?? "0.0");
-                record.Spare = (assetNode.Attributes["Model"]?.Value ?? "0") == "1";
+                record.VoltageKV = double.Parse(assetNode.Attributes["VoltageKV"]?.Value ?? "0.0");
+                record.Spare = assetNode.Attributes["Spare"]?.Value.ParseBoolean() ?? false;
                 record.Description = assetNode.Attributes["Description"]?.Value;
 
                 record.ThermalRating = double.Parse(assetNode.Attributes["ThermalRating"]?.Value ?? "0.0");
@@ -500,12 +501,12 @@ namespace openXDA.XMLConfig
                 }
 
                 record.AssetName = assetNode.Attributes["AssetName"].Value;
-                record.VoltageKV = double.Parse(assetNode.Attributes["Make"]?.Value ?? "0.0");
-                record.Spare = (assetNode.Attributes["Model"]?.Value ?? "0") == "1";
+                record.VoltageKV = double.Parse(assetNode.Attributes["VoltageKV"]?.Value ?? "0.0");
+                record.Spare = assetNode.Attributes["Spare"]?.Value.ParseBoolean() ?? false;
                 record.Description = assetNode.Attributes["Description"]?.Value;
 
                 record.NumberOfBanks = int.Parse(assetNode.Attributes["NumberOfBanks"]?.Value ?? "0");
-                record.CapacitancePerBank = double.Parse(assetNode.Attributes["Speed"]?.Value ?? "0.0");
+                record.CapacitancePerBank = double.Parse(assetNode.Attributes["CapacitancePerBank"]?.Value ?? "0.0");
                 record.CktSwitcher = assetNode.Attributes["CktSwitcher"]?.Value ?? "";
                 record.MaxKV = double.Parse(assetNode.Attributes["MaxKV"]?.Value ?? "0.0");
                 record.UnitKV = double.Parse(assetNode.Attributes["UnitKV"]?.Value ?? "0.0");
@@ -561,8 +562,8 @@ namespace openXDA.XMLConfig
                 }
 
                 record.AssetName = assetNode.Attributes["AssetName"].Value;
-                record.VoltageKV = double.Parse(assetNode.Attributes["Make"]?.Value ?? "0.0");
-                record.Spare = (assetNode.Attributes["Model"]?.Value ?? "0") == "1";
+                record.VoltageKV = double.Parse(assetNode.Attributes["VoltageKV"]?.Value ?? "0.0");
+                record.Spare = assetNode.Attributes["Spare"]?.Value.ParseBoolean() ?? false;
                 record.Description = assetNode.Attributes["Description"]?.Value;
 
                 record.R0 = double.Parse(assetNode.Attributes["R0"]?.Value ?? "0.0");
@@ -603,8 +604,8 @@ namespace openXDA.XMLConfig
                 }
 
                 record.AssetName = assetNode.Attributes["AssetName"].Value;
-                record.VoltageKV = double.Parse(assetNode.Attributes["Make"]?.Value ?? "0.0");
-                record.Spare = (assetNode.Attributes["Model"]?.Value ?? "0") == "1";
+                record.VoltageKV = double.Parse(assetNode.Attributes["VoltageKV"]?.Value ?? "0.0");
+                record.Spare = assetNode.Attributes["Spare"]?.Value.ParseBoolean() ?? false;
                 record.Description = assetNode.Attributes["Description"]?.Value;
 
                 record.OnVoltageThreshhold = double.Parse(assetNode.Attributes["OnVoltageThreshhold"]?.Value ?? "0.0");
@@ -635,8 +636,8 @@ namespace openXDA.XMLConfig
                 }
 
                 record.AssetName = assetNode.Attributes["AssetName"].Value;
-                record.VoltageKV = double.Parse(assetNode.Attributes["Make"]?.Value ?? "0.0");
-                record.Spare = (assetNode.Attributes["Model"]?.Value ?? "0") == "1";
+                record.VoltageKV = double.Parse(assetNode.Attributes["VoltageKV"]?.Value ?? "0.0");
+                record.Spare = assetNode.Attributes["Spare"]?.Value.ParseBoolean() ?? false;
                 record.Description = assetNode.Attributes["Description"]?.Value;
 
                 record.VoltageLevel = assetNode.Attributes["VoltageLevel"]?.Value ?? "Low";
@@ -667,12 +668,15 @@ namespace openXDA.XMLConfig
                 }
 
                 record.AssetName = assetNode.Attributes["AssetName"].Value;
-                record.VoltageKV = double.Parse(assetNode.Attributes["Make"]?.Value ?? "0.0");
-                record.Spare = (assetNode.Attributes["Model"]?.Value ?? "0") == "1";
+                record.VoltageKV = double.Parse(assetNode.Attributes["VoltageKV"]?.Value ?? "0.0");
+                record.Spare = assetNode.Attributes["Spare"]?.Value.ParseBoolean() ?? false;
                 record.Description = assetNode.Attributes["Description"]?.Value;
 
-                record.MaxFaultDistance = double.Parse(assetNode.Attributes["MaxFaultDistance"]?.Value ?? "0.0");
-                record.MinFaultDistance = double.Parse(assetNode.Attributes["MinFaultDistance"]?.Value ?? "0.0");
+                if (!(assetNode.Attributes["MaxFaultDistance"] is null))
+                    record.MaxFaultDistance = double.Parse(assetNode.Attributes["MaxFaultDistance"].Value);
+
+                if (!(assetNode.Attributes["MinFaultDistance"] is null))
+                    record.MinFaultDistance = double.Parse(assetNode.Attributes["MinFaultDistance"].Value);
 
                 new TableOperations<Line>(connection).AddNewOrUpdateRecord(record);
                 Log.Info($"Loaded Line {record.AssetKey}");
@@ -699,17 +703,17 @@ namespace openXDA.XMLConfig
                 }
 
                 record.AssetName = lineSegmentNode.Attributes["AssetName"].Value;
-                record.VoltageKV = double.Parse(lineSegmentNode.Attributes["Make"]?.Value ?? "0.0");
-                record.Spare = (lineSegmentNode.Attributes["Model"]?.Value ?? "0") == "1";
+                record.VoltageKV = double.Parse(lineSegmentNode.Attributes["VoltageKV"]?.Value ?? "0.0");
+                record.Spare = lineSegmentNode.Attributes["Spare"]?.Value.ParseBoolean() ?? false;
                 record.Description = lineSegmentNode.Attributes["Description"]?.Value;
 
                 record.R0 = double.Parse(lineSegmentNode.Attributes["R0"]?.Value ?? "0.0");
                 record.X0 = double.Parse(lineSegmentNode.Attributes["X0"]?.Value ?? "0.0");
-                record.R1 = int.Parse(lineSegmentNode.Attributes["R1"]?.Value ?? "0");
-                record.X1 = int.Parse(lineSegmentNode.Attributes["X1"]?.Value ?? "0");
+                record.R1 = double.Parse(lineSegmentNode.Attributes["R1"]?.Value ?? "0");
+                record.X1 = double.Parse(lineSegmentNode.Attributes["X1"]?.Value ?? "0");
                 record.ThermalRating = double.Parse(lineSegmentNode.Attributes["ThermalRating"]?.Value ?? "0.0");
                 record.Length = double.Parse(lineSegmentNode.Attributes["Length"]?.Value ?? "0.0");
-                record.IsEnd = XmlConvert.ToBoolean(lineSegmentNode.Attributes["IsEnd"]?.Value ?? "false");
+                record.IsEnd = lineSegmentNode.Attributes["IsEnd"]?.Value.ParseBoolean() ?? false;
 
                 new TableOperations<LineSegment>(connection).AddNewOrUpdateRecord(record);
             }

--- a/Source/Tools/DeviceDefinitionsMigrator/Program.cs
+++ b/Source/Tools/DeviceDefinitionsMigrator/Program.cs
@@ -34,6 +34,11 @@ using GSF.Collections;
 using GSF.Data;
 using GSF.Data.Model;
 using log4net;
+using log4net.Appender;
+using log4net.Config;
+using log4net.Core;
+using log4net.Filter;
+using log4net.Layout;
 using openXDA.Model;
 using openXDA.XMLConfig;
 
@@ -41,8 +46,6 @@ namespace DeviceDefinitionsMigrator
 {
     class Program
     {
-        private static readonly ILog Logger = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-
         private class ProgressTracker
         {
             private int m_progress;
@@ -145,6 +148,8 @@ namespace DeviceDefinitionsMigrator
 
         static void Main(string[] args)
         {
+            InitializeLogging();
+
             if (args.Length != 3)
             {
                 PrintHelp();
@@ -183,6 +188,22 @@ namespace DeviceDefinitionsMigrator
                 Console.Error.WriteLine("--- ERROR ---");
                 Console.Error.WriteLine(ex.ToString());
             }
+        }
+
+        private static void InitializeLogging()
+        {
+            ConsoleAppender stdout = new ConsoleAppender();
+            stdout.Layout = new PatternLayout("%message%newline");
+            stdout.AddFilter(new LevelRangeFilter() { LevelMax = Level.Notice });
+            stdout.ActivateOptions();
+
+            ConsoleAppender stderr = new ConsoleAppender();
+            stderr.Layout = new PatternLayout("%-5level %message%newline%exception");
+            stderr.Target = "Console.Error";
+            stderr.AddFilter(new LevelRangeFilter() { LevelMin = Level.Warn });
+            stderr.ActivateOptions();
+
+            BasicConfigurator.Configure(stdout, stderr);
         }
 
         private static void PrintHelp() {


### PR DESCRIPTION
When the compression option was added to `Transform.ToCycleDataGroup()`, the loop that produces y-values and t-values for the sine wave curve fitting algorithm was mistakenly adjusted to use the beginning of the `DataSeries` as t=0 instead of the beginning of the cycle. The fix was buried deeply in the analysis logic but only required changing a single line of code to fix it.

The rest of the commits in this PR are changes I needed to make to DeviceDefinitionsMigrator v2 logic in order to load meter configuration and process the test data that was provided.