### PR TITLE
XDA-89 Refactor EMAX-to-COMTRADE conversion into a data operation

### DIFF
--- a/Source/Libraries/FaultData/DataOperations/EMAXConversionOperation.cs
+++ b/Source/Libraries/FaultData/DataOperations/EMAXConversionOperation.cs
@@ -1,0 +1,215 @@
+﻿//******************************************************************************************************
+//  EMAXConversionOperation.cs - Gbtc
+//
+//  Copyright © 2026, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  06/09/2026 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using FaultData.DataAnalysis;
+using FaultData.DataSets;
+using GSF;
+using GSF.COMTRADE;
+using GSF.Configuration;
+using GSF.EMAX;
+using openXDA.Configuration;
+using openXDA.Model;
+
+namespace FaultData.DataOperations
+{
+    public class EMAXConversionOperation : DataOperationBase<MeterDataSet>
+    {
+        [Category]
+        [SettingName(EMAXSection.CategoryName)]
+        public EMAXSection EMAXSettings { get; }
+            = new EMAXSection();
+
+        private string ExportDirectory =>
+            EMAXSettings.COMTRADEExportDirectory;
+
+        public override void Execute(MeterDataSet meterDataSet)
+        {
+            if (string.IsNullOrEmpty(ExportDirectory))
+                return;
+
+            EMAXConversionDataSet emaxConversionDataSet = meterDataSet.EMAXConversionDataSet;
+
+            if (emaxConversionDataSet is null)
+                return;
+
+            ControlFile controlFile = emaxConversionDataSet.ControlFile;
+            List<DataSeries> analogData = emaxConversionDataSet.AnalogData;
+            List<DataSeries> digitalData = emaxConversionDataSet.DigitalData;
+
+            string rootFileName = GSF.IO.FilePath.GetFileNameWithoutExtension(controlFile.FileName);
+            string directoryPath = GetExportDirectory(meterDataSet.Meter);
+            string schemaFilePath = Path.Combine(directoryPath, $"{rootFileName}.cfg");
+            string dataFilePath = Path.Combine(directoryPath, $"{rootFileName}.dat");
+
+            if (File.Exists(dataFilePath))
+                return;
+
+            List<ANLG_CHNL_NEW> analogChannels = [.. controlFile.AnalogChannelSettings
+                .OrderBy(kvp => kvp.Key)
+                .Select(kvp => kvp.Value)];
+
+            List<EVNT_CHNL_NEW> digitalChannels = [.. controlFile.EventChannelSettings
+                .OrderBy(kvp => kvp.Key)
+                .Select(kvp => kvp.Value)];
+
+            Schema comtradeSchema = CreateSchema(controlFile, analogData);
+            PopulateAnalogs(comtradeSchema, analogChannels, analogData);
+            PopulateDigitals(comtradeSchema, digitalChannels);
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(schemaFilePath, comtradeSchema.FileImage, Encoding.ASCII);
+
+            const int DigitalSize = sizeof(ushort) * 8;
+            using FileStream stream = File.OpenWrite(dataFilePath);
+
+            IEnumerable<DataSeries> digitalWords = digitalData.Skip(1)
+                .Select((dataSeries, index) => dataSeries.Multiply(Math.Pow(2.0D, DigitalSize - (index % DigitalSize) - 1)))
+                .Select((DataSeries, Index) => new { DataSeries, Index })
+                .GroupBy(obj => obj.Index / DigitalSize)
+                .Select(grouping => grouping.Select(obj => obj.DataSeries))
+                .Select(grouping => grouping.Aggregate((sum, series) => sum.Add(series)));
+
+            List<DataSeries> allChannels = [.. analogData.Skip(1)
+                .Select((dataSeries, index) => analogChannels[index].type.All(char.IsUpper) ? dataSeries.Multiply(0.001D) : dataSeries)
+                .Concat(digitalWords)];
+
+            for (int i = 0; i < analogData[1].DataPoints.Count; i++)
+            {
+                DateTime timestamp = analogData[1][i].Time;
+                double[] values = [.. allChannels.Select(dataSeries => dataSeries[i].Value)];
+                Writer.WriteNextRecordBinary(stream, comtradeSchema, timestamp, values, (uint)i, false);
+            }
+        }
+
+        private Schema CreateSchema(ControlFile controlFile, List<DataSeries> analogData)
+        {
+            Schema comtradeSchema = new();
+
+            comtradeSchema.StationName = Regex.Replace(controlFile.IdentityString.value, @"[\r\n]", "");
+            comtradeSchema.Version = 2013;
+            comtradeSchema.AnalogChannels = new AnalogChannel[controlFile.AnalogChannelCount];
+            comtradeSchema.DigitalChannels = new DigitalChannel[controlFile.EventChannelSettings.Count];
+            comtradeSchema.SampleRates = new SampleRate[1];
+            comtradeSchema.SampleRates[0].Rate = controlFile.SystemParameters.samples_per_second;
+            comtradeSchema.SampleRates[0].EndSample = controlFile.SystemParameters.rcd_sample_count - 1;
+            comtradeSchema.StartTime = new Timestamp() { Value = analogData[1][0].Time };
+
+            int triggerIndex = controlFile.SystemParameters.start_offset_samples + controlFile.SystemParameters.prefault_samples;
+            comtradeSchema.TriggerTime = new Timestamp() { Value = analogData[1][triggerIndex].Time };
+
+            return comtradeSchema;
+        }
+
+        private void PopulateAnalogs(Schema comtradeSchema, List<ANLG_CHNL_NEW> analogChannels, List<DataSeries> analogData)
+        {
+            for (int i = 0; i < analogChannels.Count; i++)
+            {
+                ANLG_CHNL_NEW analogChannel = analogChannels[i];
+                AnalogChannel comtradeAnalog = new();
+                DataSeries channelData = analogData[i + 1];
+
+                double unitMultiplier = 1.0D;
+                double max = channelData.Maximum;
+                double min = channelData.Minimum;
+
+                comtradeAnalog.Index = i + 1;
+                comtradeAnalog.CircuitComponent = analogChannel.title;
+                comtradeAnalog.Name = "A" + (i + 1);
+
+                comtradeAnalog.Units = analogChannel.type switch
+                {
+                    "V" => "kVAC",
+                    "A" => "kAAC",
+                    "v" => " VDC",
+                    string type => type,
+                };
+
+                if (analogChannel.type.All(char.IsUpper))
+                {
+                    unitMultiplier = 0.001D;
+                    max *= unitMultiplier;
+                    min *= unitMultiplier;
+                }
+
+                comtradeAnalog.Multiplier = (max - min) / (2 * short.MaxValue);
+                comtradeAnalog.Adder = (max + min) / 2.0D;
+
+                // Setting Secondary to 1 and adjusting primary accordingly (for human readability)
+                double basePrimary = double.TryParse(analogChannel.primary, out double num) ? num * unitMultiplier : 0.0D;
+                double inverseSecondaryMultiplier = double.TryParse(analogChannel.secondary, out num) ? num * unitMultiplier : 0.0D;
+
+                if (inverseSecondaryMultiplier != 0.0D)
+                {
+                    comtradeAnalog.PrimaryRatio = basePrimary / inverseSecondaryMultiplier;
+                    comtradeAnalog.SecondaryRatio = 1.0D;
+                }
+                else
+                {
+                    comtradeAnalog.PrimaryRatio = basePrimary;
+                    comtradeAnalog.SecondaryRatio = 0.0D;
+                }
+
+                comtradeSchema.AnalogChannels[i] = comtradeAnalog;
+            }
+        }
+
+        private void PopulateDigitals(Schema comtradeSchema, List<EVNT_CHNL_NEW> digitalChannels)
+        {
+            for (int i = 0; i < digitalChannels.Count; i++)
+            {
+                EVNT_CHNL_NEW digitalChannel = digitalChannels[i];
+                DigitalChannel comtradeDigital = new();
+                comtradeDigital.Index = i + 1;
+                comtradeDigital.CircuitComponent = digitalChannel.e_title;
+                comtradeDigital.ChannelName = "E" + (i + 1);
+                comtradeDigital.PhaseID = "?";
+                comtradeSchema.DigitalChannels[i] = comtradeDigital;
+            }
+        }
+
+        private string GetExportDirectory(Meter meter)
+        {
+            var templateData = new
+            {
+                meter.Location.LocationKey,
+                LocationName = meter.Location.Name,
+
+                meter.AssetKey,
+                meter.Name,
+                meter.Make,
+                meter.Model,
+                meter.Alias,
+                meter.ShortName
+            };
+
+            return ExportDirectory.Interpolate(templateData);
+        }
+    }
+}

--- a/Source/Libraries/FaultData/DataReaders/EMAXReader.cs
+++ b/Source/Libraries/FaultData/DataReaders/EMAXReader.cs
@@ -26,11 +26,9 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using FaultData.DataAnalysis;
 using FaultData.DataSets;
-using GSF.COMTRADE;
 using GSF.Configuration;
 using GSF.EMAX;
 using log4net;
@@ -41,143 +39,6 @@ namespace FaultData.DataReaders
 {
     public class EMAXReader : IDataReader
     {
-        #region [ Members ]
-
-        // Nested Types
-        private class COMTRADEExporter
-        {
-            public string ExportDirectory { get; set; }
-
-            public MeterDataSet MeterDataSet { get; set; }
-            public string FilePath { get; set; }
-            public string MeterKey { get; set; }
-            public string IdentityString { get; set; }
-
-            public ControlFile ControlFile { get; set; }
-            public List<ANLG_CHNL_NEW> AnalogChannels { get; set; }
-            public List<EVNT_CHNL_NEW> DigitalChannels { get; set; }
-
-            public void ExportToCOMTRADE()
-            {
-                string rootFileName = GSF.IO.FilePath.GetFileNameWithoutExtension(FilePath);
-                string directoryPath = Path.Combine(ExportDirectory, MeterKey);
-                string schemaFilePath = Path.Combine(directoryPath, $"{rootFileName}.cfg");
-                string dataFilePath = Path.Combine(directoryPath, $"{rootFileName}.dat");
-                Schema comtradeSchema = new Schema();
-
-                if (File.Exists(dataFilePath))
-                    return;
-
-                comtradeSchema.StationName = Regex.Replace(IdentityString, @"[\r\n]", "");
-                comtradeSchema.Version = 2013;
-                comtradeSchema.AnalogChannels = new AnalogChannel[ControlFile.AnalogChannelCount];
-                comtradeSchema.DigitalChannels = new DigitalChannel[ControlFile.EventChannelSettings.Count];
-                comtradeSchema.SampleRates = new SampleRate[1];
-                comtradeSchema.SampleRates[0].Rate = ControlFile.SystemParameters.samples_per_second;
-                comtradeSchema.SampleRates[0].EndSample = ControlFile.SystemParameters.rcd_sample_count - 1;
-                comtradeSchema.StartTime = new Timestamp() { Value = MeterDataSet.DataSeries[1][0].Time };
-
-                int triggerIndex = ControlFile.SystemParameters.start_offset_samples + ControlFile.SystemParameters.prefault_samples;
-                comtradeSchema.TriggerTime = new Timestamp() { Value = MeterDataSet.DataSeries[1][triggerIndex].Time };
-
-                for (int i = 0; i < AnalogChannels.Count; i++)
-                {
-                    ANLG_CHNL_NEW analogChannel = AnalogChannels[i];
-                    AnalogChannel comtradeAnalog = new AnalogChannel();
-                    DataSeries channelData = MeterDataSet.DataSeries[i + 1];
-
-                    double unitMultiplier = 1.0D;
-                    double max = channelData.Maximum;
-                    double min = channelData.Minimum;
-                    double num;
-
-                    comtradeAnalog.Index = i + 1;
-                    comtradeAnalog.CircuitComponent = analogChannel.title;
-                    comtradeAnalog.Name = "A" + (i + 1);
-
-                    comtradeAnalog.Units = new Func<string, string>(type =>
-                    {
-                        switch (type)
-                        {
-                            case "V": return "kVAC";
-                            case "A": return "kAAC";
-                            case "v": return " VDC";
-                            default: return type;
-                        }
-                    })(analogChannel.type);
-
-                    if (analogChannel.type.All(char.IsUpper))
-                    {
-                        unitMultiplier = 0.001D;
-                        max *= unitMultiplier;
-                        min *= unitMultiplier;
-                    }
-
-                    comtradeAnalog.Multiplier = (max - min) / (2 * short.MaxValue);
-                    comtradeAnalog.Adder = (max + min) / 2.0D;
-                    // Setting Secondary to 1 and adjusting primary accordingly (for human readability)
-                    double basePrimary = double.TryParse(analogChannel.primary, out num) ? num * unitMultiplier : 0.0D;
-                    double inverseSecondaryMultiplier = double.TryParse(analogChannel.secondary, out num) ? num * unitMultiplier : 0.0D;
-                    if (inverseSecondaryMultiplier != 0.0D)
-                    {
-                        comtradeAnalog.PrimaryRatio = basePrimary / inverseSecondaryMultiplier;
-                        comtradeAnalog.SecondaryRatio = 1.0D;
-                    }
-                    else
-                    {
-                        comtradeAnalog.PrimaryRatio = basePrimary;
-                        comtradeAnalog.SecondaryRatio = 0.0D;
-                    }
-
-                    comtradeSchema.AnalogChannels[i] = comtradeAnalog;
-                }
-
-                for (int i = 0; i < DigitalChannels.Count; i++)
-                {
-                    EVNT_CHNL_NEW digitalChannel = DigitalChannels[i];
-                    DigitalChannel comtradeDigital = new DigitalChannel();
-                    comtradeDigital.Index = i + 1;
-                    comtradeDigital.CircuitComponent = digitalChannel.e_title;
-                    comtradeDigital.ChannelName = "E" + (i + 1);
-                    comtradeDigital.PhaseID = "?";
-                    comtradeSchema.DigitalChannels[i] = comtradeDigital;
-                }
-
-                Directory.CreateDirectory(directoryPath);
-                File.WriteAllText(schemaFilePath, comtradeSchema.FileImage, Encoding.ASCII);
-
-                using (FileStream stream = File.OpenWrite(dataFilePath))
-                {
-                    const int DigitalSize = sizeof(ushort) * 8;
-
-                    IEnumerable<DataSeries> digitalWords = MeterDataSet.Digitals.Skip(1)
-                        .Select((dataSeries, index) => dataSeries.Multiply(Math.Pow(2.0D, DigitalSize - (index % DigitalSize) - 1)))
-                        .Select((DataSeries, Index) => new { DataSeries, Index })
-                        .GroupBy(obj => obj.Index / DigitalSize)
-                        .Select(grouping => grouping.Select(obj => obj.DataSeries))
-                        .Select(grouping => grouping.Aggregate((sum, series) => sum.Add(series)));
-
-                    List<DataSeries> allChannels = MeterDataSet.DataSeries.Skip(1)
-                        .Select((dataSeries, index) => AnalogChannels[index].type.All(char.IsUpper) ? dataSeries.Multiply(0.001D) : dataSeries)
-                        .Concat(digitalWords)
-                        .ToList();
-
-                    for (int i = 0; i < MeterDataSet.DataSeries[1].DataPoints.Count; i++)
-                    {
-                        DateTime timestamp = MeterDataSet.DataSeries[1][i].Time;
-
-                        double[] values = allChannels
-                            .Select(dataSeries => dataSeries[i].Value)
-                            .ToArray();
-
-                        Writer.WriteNextRecordBinary(stream, comtradeSchema, timestamp, values, (uint)i, false);
-                    }
-                }
-            }
-        }
-
-        #endregion
-
         #region [ Properties ]
 
         /// <summary>
@@ -363,37 +224,7 @@ namespace FaultData.DataReaders
                 }
             }
 
-            try
-            {
-                if (!string.IsNullOrEmpty(EMAXSettings.COMTRADEExportDirectory))
-                {
-                    string filePath = parser.FileName;
-
-                    string meterKey = GetMeterKey(filePath, FileProcessorSettings.FilePattern)
-                        ?? ThreadContext.Properties["Meter"].ToString();
-
-                    COMTRADEExporter exporter = new COMTRADEExporter()
-                    {
-                        ExportDirectory = EMAXSettings.COMTRADEExportDirectory,
-
-                        MeterDataSet = meterDataSet,
-                        FilePath = filePath,
-                        MeterKey = meterKey,
-                        IdentityString = identityString,
-
-                        ControlFile = controlFile,
-                        AnalogChannels = analogChannels,
-                        DigitalChannels = digitalChannels
-                    };
-
-                    exporter.ExportToCOMTRADE();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex.Message, ex);
-            }
-
+            meterDataSet.EMAXConversionDataSet = new(controlFile, meterDataSet);
             return meterDataSet;
         }
 

--- a/Source/Libraries/FaultData/DataSets/EMAXConversionDataSet.cs
+++ b/Source/Libraries/FaultData/DataSets/EMAXConversionDataSet.cs
@@ -1,0 +1,36 @@
+﻿//******************************************************************************************************
+//  EMAXConversionDataSet.cs - Gbtc
+//
+//  Copyright © 2026, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  06/09/2026 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System.Collections.Generic;
+using FaultData.DataAnalysis;
+using GSF.EMAX;
+
+namespace FaultData.DataSets
+{
+    public class EMAXConversionDataSet(ControlFile controlFile, MeterDataSet parsedData)
+    {
+        public ControlFile ControlFile { get; } = controlFile;
+        public List<DataSeries> AnalogData { get; } = [.. parsedData.DataSeries];
+        public List<DataSeries> DigitalData { get; } = [.. parsedData.Digitals];
+    }
+}

--- a/Source/Libraries/FaultData/DataSets/MeterDataSet.cs
+++ b/Source/Libraries/FaultData/DataSets/MeterDataSet.cs
@@ -86,6 +86,7 @@ namespace FaultData.DataSets
         public List<string> Triggers { get; set; }
 
         private Dictionary<Type, object> Resources { get; set; }
+        public EMAXConversionDataSet EMAXConversionDataSet { get; set; }
         public BreakerRestrikeDataSet BreakerRestrikeDataSet { get; set; }
         public AnalysisDataSet AnalysisDataSet { get; set; }
         public CyclicHistogramDataSet CyclicHistogramDataSet { get; set; }

--- a/Source/Libraries/FaultData/FaultData.csproj
+++ b/Source/Libraries/FaultData/FaultData.csproj
@@ -119,6 +119,7 @@
     <Compile Include="DataAnalysis\VIDataGroup.cs" />
     <Compile Include="DataOperations\BreakerRestrikeOperation.cs" />
     <Compile Include="DataOperations\BreakerTimingOperation.cs" />
+    <Compile Include="DataOperations\EMAXConversionOperation.cs" />
     <Compile Include="DataOperations\LSCVSDataOperation.cs" />
     <Compile Include="DataOperations\ConfigurationOperation.cs" />
     <Compile Include="DataOperations\DataOperationBase.cs" />
@@ -171,6 +172,7 @@
     <Compile Include="DataResources\TransientDataResource.cs" />
     <Compile Include="DataSets\AnalysisDataSet.cs" />
     <Compile Include="DataSets\CyclicHistogramDataSet.cs" />
+    <Compile Include="DataSets\EMAXConversionDataSet.cs" />
     <Compile Include="DataSets\GTC\BreakerRestrikeDataSet.cs" />
     <Compile Include="DataSets\IDataSet.cs" />
     <Compile Include="DataResources\TrendingDataSummaryResource.cs" />


### PR DESCRIPTION
* Move code from `DataReader.COMTRADEExporter` nested class into `EMAXConversionOperation`
* Refactor the code to reduce the size of the `EMAXConversionOperation.Execute()` method by moving COMTRADE schema file setup into a handful of helper methods
* Add `EMAXConversionOperation.GetExportDirectory()` to compute an export directory using a templated expression
* Add `EMAXConversionDataSet` to `MeterDataSet` in order to capture data from the `EMAXReader` required by the conversion

The new `EMAXConversionOperation` should be added to the pipeline after the `ConfigurationOperation` so that the meter's location data will be populated by data from the database.