### PR TITLE
make NodeSetting searchable

### DIFF
--- a/Source/Libraries/openXDA.Model/Nodes/NodeSetting.cs
+++ b/Source/Libraries/openXDA.Model/Nodes/NodeSetting.cs
@@ -25,6 +25,7 @@ using GSF.Data.Model;
 
 namespace openXDA.Model
 {
+    [AllowSearch]
     public class NodeSetting
     {
         [PrimaryKey(true)]


### PR DESCRIPTION
Allow NodeSettings to be searched, particularly in the Task Runner Settings tab in System Center