### PR TITLE
Added FTT Authentication

### DIFF
--- a/Source/Libraries/OpenXDA.NotificationDataSources/FaultTraceTool/FTTDataSource.cs
+++ b/Source/Libraries/OpenXDA.NotificationDataSources/FaultTraceTool/FTTDataSource.cs
@@ -21,13 +21,6 @@
 //
 //******************************************************************************************************
 
-using Azure.Core;
-using GSF;
-using GSF.Data;
-using GSF.Data.Model;
-using Newtonsoft.Json.Linq;
-using openXDA.Model;
-using openXDA.PQI;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -35,10 +28,14 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Net;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using GSF;
+using GSF.Data;
+using GSF.Data.Model;
+using Newtonsoft.Json.Linq;
+using openXDA.Model;
+using openXDA.PQI;
 
 namespace openXDA.NotificationDataSources.FaultTraceTool
 {
@@ -182,7 +179,6 @@ namespace openXDA.NotificationDataSources.FaultTraceTool
                 body.Add(new KeyValuePair<string, string>("expiration", "60"));
                 body.Add(new KeyValuePair<string, string>("f", "json"));
                 request.Content = new FormUrlEncodedContent(body);
-
             }
 
             using (HttpResponseMessage response = await HttpClient.SendRequestAsync(ConfigureRequest).ConfigureAwait(false))
@@ -195,13 +191,11 @@ namespace openXDA.NotificationDataSources.FaultTraceTool
                 string accessToken = content["token"].Value<string>();
                 return accessToken;
             }
-
         }
-
-
 
         private static HttpClient HttpClient =>
             HttpClientProvider.GetClient();
+
         #endregion
     }
 

--- a/Source/Libraries/OpenXDA.NotificationDataSources/FaultTraceTool/FTTDataSource.cs
+++ b/Source/Libraries/OpenXDA.NotificationDataSources/FaultTraceTool/FTTDataSource.cs
@@ -21,16 +21,24 @@
 //
 //******************************************************************************************************
 
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.IO;
-using System.Linq;
-using System.Xml.Linq;
+using Azure.Core;
 using GSF;
 using GSF.Data;
 using GSF.Data.Model;
+using Newtonsoft.Json.Linq;
 using openXDA.Model;
+using openXDA.PQI;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net;
+using System.Threading.Tasks;
+using System.Xml.Linq;
 
 namespace openXDA.NotificationDataSources.FaultTraceTool
 {
@@ -97,6 +105,11 @@ namespace openXDA.NotificationDataSources.FaultTraceTool
                 .Concat(records.Select(GetQueryString))
                 .Where(queryPart => !string.IsNullOrEmpty(queryPart));
 
+            if (!string.IsNullOrEmpty(FTTOptions.TokenURL))
+            {
+                queryParts.Append($"token={GetToken()}");
+            }
+
             return string.Join("&", queryParts);
         }
 
@@ -107,6 +120,11 @@ namespace openXDA.NotificationDataSources.FaultTraceTool
             IEnumerable<string> queryParts = new[] { builder.Query.TrimStart('?'), $"totalLine={records.Count()}" }
                 .Concat(records.Select(GetQueryString))
                 .Where(queryPart => !string.IsNullOrEmpty(queryPart));
+
+            if (!string.IsNullOrEmpty(FTTOptions.TokenURL))
+            {
+                queryParts.Append($"token={GetToken()}");
+            }
 
             builder.Query = string.Join("&", queryParts);
 
@@ -144,6 +162,58 @@ namespace openXDA.NotificationDataSources.FaultTraceTool
             }
         }
 
+        /// <summary>
+        /// Gets the Token using the TokenURl, User and Password
+        /// </summary>
+        /// <returns></returns>
+        private async Task<string> GetToken()
+        {
+            void ConfigureRequest(HttpRequestMessage request)
+            {
+                request.RequestUri = new Uri(FTTOptions.TokenURL);
+                request.Method = HttpMethod.Post;
+
+                List<KeyValuePair<string, string>> body = new List<KeyValuePair<string, string>>();
+                body.Add(new KeyValuePair<string, string>("username", FTTOptions.TokenUser));
+                body.Add(new KeyValuePair<string, string>("password", FTTOptions.TokenPassword));
+                body.Add(new KeyValuePair<string, string>("client", "referer"));
+                body.Add(new KeyValuePair<string, string>("ip", ""));
+                body.Add(new KeyValuePair<string, string>("referer", "https://gisdu.tva.gov/openftt/"));
+                body.Add(new KeyValuePair<string, string>("expiration", "60"));
+                body.Add(new KeyValuePair<string, string>("f", "json"));
+                request.Content = new FormUrlEncodedContent(body);
+
+            }
+
+            using (HttpResponseMessage response = await HttpClient.SendRequestAsync(ConfigureRequest).ConfigureAwait(false))
+            {
+                response.EnsureSuccessStatusCode();
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
+                JObject content = JObject.Parse(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
+                int expiration = content["expires"].Value<int>();
+                string accessToken = content["token"].Value<string>();
+                return accessToken;
+            }
+
+        }
+
+
+
+        private static HttpClient HttpClient =>
+            HttpClientProvider.GetClient();
         #endregion
+    }
+
+    internal static class HttpClientExtensions
+    {
+        public static async Task<HttpResponseMessage> SendRequestAsync(this HttpClient client, Action<HttpRequestMessage> configure)
+        {
+            using (HttpRequestMessage request = new HttpRequestMessage())
+            {
+                configure(request);
+                return await client.SendAsync(request).ConfigureAwait(false);
+            }
+        }
     }
 }

--- a/Source/Libraries/OpenXDA.NotificationDataSources/FaultTraceTool/FTTOptions.cs
+++ b/Source/Libraries/OpenXDA.NotificationDataSources/FaultTraceTool/FTTOptions.cs
@@ -84,5 +84,17 @@ namespace openXDA.NotificationDataSources.FaultTraceTool
         [Setting]
         [DefaultValue("")]
         public string BrowserArguments { get; set; }
+
+        [Setting]
+        [DefaultValue("")]
+        public string TokenURL { get; set; }
+
+        [Setting]
+        [DefaultValue("")]
+        public string TokenUser { get; set; }
+
+        [Setting]
+        [DefaultValue("")]
+        public string TokenPassword { get; set; }
     }
 }

--- a/Source/Libraries/OpenXDA.NotificationDataSources/openXDA.NotificationDataSources.csproj
+++ b/Source/Libraries/OpenXDA.NotificationDataSources/openXDA.NotificationDataSources.csproj
@@ -119,6 +119,7 @@
       <HintPath>..\..\Dependencies\NuGet\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>


### PR DESCRIPTION
This adds authetication to the fault trace tool.

1. Generate a token
(a) [POST, url-encoded form] {GIS Url}/sharing/rest/generateToken
(b) Use username/password that was provided

2. Proceed to OpenFTT
(a) {GIS Url}/openftt?token={token}
(b) With token as a url parameter, it will use this as authentication instead

