### PR TITLE
Deprioritize files that have been recently queued

### DIFF
--- a/Source/Data/05 - DefaultSettings.sql
+++ b/Source/Data/05 - DefaultSettings.sql
@@ -272,6 +272,12 @@ GO
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('FileWatcher.BufferSize', '65536', '65536')
 GO
 
+INSERT INTO Setting(Name, Value, DefaultValue) VALUES('FileWatcher.DeprioritizationThreshold', '0.0', '0.0')
+GO
+
+INSERT INTO Setting(Name, Value, DefaultValue) VALUES('FileWatcher.HighPriorityPaths', '', '')
+GO
+
 INSERT INTO Setting(Name, Value, DefaultValue) VALUES('FileWatcher.InternalThreadCount', '0', '0')
 GO
 

--- a/Source/Libraries/openXDA.Configuration/FileWatcherSection.cs
+++ b/Source/Libraries/openXDA.Configuration/FileWatcherSection.cs
@@ -274,6 +274,25 @@ namespace openXDA.Configuration
             .ToArray();
 
         /// <summary>
+        /// Gets or sets a threshold, in hours, for the amount of time a given file group will
+        /// be deprioritized by the file watcher after having been queued at normal priority.
+        /// </summary>
+        [Setting]
+        [SettingName(nameof(DeprioritizationThreshold))]
+        [DefaultValue(0.0D)]
+        public double DeprioritizationThresholdHours
+        {
+            get => DeprioritizationThreshold.TotalHours;
+            set => DeprioritizationThreshold = TimeSpan.FromHours(value);
+        }
+
+        /// <summary>
+        /// Gets or sets a threshold for the amount of time a given file group will be
+        /// deprioritized by the file watcher after having been queued at normal priority.
+        /// </summary>
+        public TimeSpan DeprioritizationThreshold { get; set; }
+
+        /// <summary>
         /// Gets or sets the number of threads used
         /// internally to the file processor.
         /// </summary>

--- a/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileGroupInfo.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileGroupInfo.cs
@@ -35,6 +35,8 @@ namespace openXDA.Nodes.Types.FileProcessing
             .Where(fileInfo => fileInfo.Exists)
             .ToArray();
 
+        public DateTime LastQueuedAtWatcherPriority { get; set; }
+
         private Func<FileInfo[]> FileGroupFunc { get; }
 
         internal FileGroupInfo(string fileGroupPath, Func<FileInfo[]> fileGroupFunc)

--- a/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileProcessorNode.cs
+++ b/Source/Libraries/openXDA.Nodes/Types/FileProcessing/FileProcessorNode.cs
@@ -172,6 +172,7 @@ namespace openXDA.Nodes.Types.FileProcessing
         private string Filter { get; set; }
         private int ProcessingThreadCount { get; set; }
         private string[] HighPriorityPaths { get; set; }
+        private TimeSpan DeprioritizationThreshold { get; set; }
         private IEnumerable<FileShare> FileShares { get; set; }
 
         private FileProcessorIndex FileProcessorIndex
@@ -422,6 +423,7 @@ namespace openXDA.Nodes.Types.FileProcessing
             Filter = QueryFilter();
             ProcessingThreadCount = settings.FileProcessorSettings.ProcessingThreadCount;
             HighPriorityPaths = settings.FileWatcherSettings.HighPriorityPathList;
+            DeprioritizationThreshold = settings.FileWatcherSettings.DeprioritizationThreshold;
             AuthenticateFileShares(settings);
             ConfigureFileProcessor(settings);
         }
@@ -625,6 +627,7 @@ namespace openXDA.Nodes.Types.FileProcessing
             if (IsDisposed)
                 return;
 
+            DateTime now = DateTime.UtcNow;
             Interlocked.Increment(ref m_scannedFileCount);
 
             string filePath = fileProcessorEventArgs.FullPath;
@@ -636,13 +639,22 @@ namespace openXDA.Nodes.Types.FileProcessing
                 return;
             }
 
-            int priority = fileProcessorEventArgs.RaisedByFileWatcher
+            DateTime deprioritizationThreshold = now - DeprioritizationThreshold;
+
+            bool queueAtWatcherPriority =
+                fileProcessorEventArgs.RaisedByFileWatcher &&
+                fileGroupInfo.LastQueuedAtWatcherPriority < deprioritizationThreshold;
+
+            int priority = queueAtWatcherPriority
                 ? GetFileWatcherPriority(filePath)
                 : AnalysisTask.FileEnumerationPriority;
 
             WorkItem workItem = new WorkItem(fileGroupInfo, filePath, priority);
             WorkQueue.Enqueue(workItem);
             PollOperation.RunOnceAsync();
+
+            if (queueAtWatcherPriority)
+                fileGroupInfo.LastQueuedAtWatcherPriority = now;
         }
 
         private void FileProcessor_Error(object sender, ErrorEventArgs args)


### PR DESCRIPTION
* Add `FileWatcher.DeprioritizationThreshold` to system settings
* Save `LastQueuedAtWatcherPriority` to the file index
  * This will be saved in-memory, associated with the whole file group
  * The file index gets recreated in `OnReconfigure()`, so updating configuration in system settings will cause the system to forget `LastQueuedAtWatcherPriority`
  * `WatchDirectoryBalancerNode` invokes `ReconfigureWatchDirectories()` which bypasses `OnReconfigure()` so it thankfully does not recreate the index
* Default deprioritization threshold is 0, meaning it shouldn't deprioritize at all unless the system clock changes